### PR TITLE
Restore vibrance to what was changed, not to where focus landed (#60, #36, #144, #95)

### DIFF
--- a/vibrance.GUI/AMD/AmdDynamicVibranceProxy.cs
+++ b/vibrance.GUI/AMD/AmdDynamicVibranceProxy.cs
@@ -72,6 +72,7 @@ namespace vibrance.GUI.AMD
         public void SetVibranceWindowsLevel(int vibranceWindowsLevel)
         {
             _vibranceInfo.userVibranceSettingDefault = vibranceWindowsLevel;
+            _vibranceInfo.isWindowsLevelKnown = true;
         }
 
         public void SetVibranceIngameLevel(int vibranceIngameLevel)
@@ -87,7 +88,12 @@ namespace vibrance.GUI.AMD
 
         public void HandleDvcExit()
         {
-            _amdAdapter.SetSaturationOnAllDisplays(_vibranceInfo.userVibranceSettingDefault);
+            // Same restore this proxy now runs from both its OnWinEventHook restore branch and
+            // here, in place of the old unconditional SetSaturationOnAllDisplays(...) both used to
+            // call regardless of affectPrimaryMonitorOnly (issue #60/#36 on AMD: the flag was never
+            // consulted here, so a second monitor's level was stomped on every exit even with the
+            // checkbox on).
+            RestoreWindowsVibranceLevel();
         }
 
         public void SetAffectPrimaryMonitorOnly(bool affectPrimaryMonitorOnly)
@@ -114,8 +120,8 @@ namespace vibrance.GUI.AMD
                 {
                     //test if a resolution change is needed
                     Screen screen = Screen.FromHandle(e.Handle);
-                    if (_vibranceInfo.neverChangeResolution == false && 
-                        applicationSetting.IsResolutionChangeNeeded && 
+                    if (_vibranceInfo.neverChangeResolution == false &&
+                        applicationSetting.IsResolutionChangeNeeded &&
                         IsResolutionChangeNeeded(screen, applicationSetting.ResolutionSettings) &&
                         _windowsResolutionSettings.ContainsKey(screen.DeviceName) &&
                         _windowsResolutionSettings[screen.DeviceName].Item2.Contains(applicationSetting.ResolutionSettings))
@@ -124,14 +130,33 @@ namespace vibrance.GUI.AMD
                         PerformResolutionChange(screen, applicationSetting.ResolutionSettings);
                     }
 
-                    _amdAdapter.SetSaturationOnAllDisplays(_vibranceInfo.userVibranceSettingDefault);
+                    // The unconditional SetSaturationOnAllDisplays(userVibranceSettingDefault) that
+                    // used to run here, before applying the game's level, is gone (issue #60/#36 on
+                    // AMD, apply side): it reset every attached display's saturation to the Windows
+                    // level - ignoring affectPrimaryMonitorOnly entirely - immediately before one of
+                    // the two branches below overwrote some or all of that same reset with the
+                    // game's level. Every display it touched was either about to be overwritten by
+                    // this same event (a visible flash, no lasting effect) or, with the flag on, a
+                    // non-game display it had no business touching at all - removing it changes no
+                    // display's final state.
                     if (_vibranceInfo.affectPrimaryMonitorOnly)
                     {
                         _amdAdapter.SetSaturationOnDisplay(applicationSetting.IngameLevel, screen.DeviceName);
+                        // Only the game's own screen was written - that is the only display owing
+                        // a restore.
+                        VibranceRestoreHelper.RecordGameLevelApplied(screen.DeviceName);
                     }
                     else
                     {
                         _amdAdapter.SetSaturationOnAllDisplays(applicationSetting.IngameLevel);
+                        // This branch really did write every attached display, not just the game's
+                        // own - unlike NVIDIA's equivalent, IAmdAdapter has no per-display read-back
+                        // to confirm any of them individually, so every currently attached display
+                        // is recorded as owing a restore.
+                        foreach (Screen attachedScreen in Screen.AllScreens)
+                        {
+                            VibranceRestoreHelper.RecordGameLevelApplied(attachedScreen.DeviceName);
+                        }
                     }
                 }
                 else
@@ -142,16 +167,51 @@ namespace vibrance.GUI.AMD
 
                     //test if a resolution change is needed
                     Screen screen = Screen.FromHandle(processHandle);
-                    if (_vibranceInfo.neverChangeResolution == false && 
-                        _gameScreen != null && _gameScreen.Equals(screen) && 
+                    if (_vibranceInfo.neverChangeResolution == false &&
+                        _gameScreen != null && _gameScreen.Equals(screen) &&
                         _windowsResolutionSettings.ContainsKey(screen.DeviceName) &&
                         IsResolutionChangeNeeded(screen, _windowsResolutionSettings[screen.DeviceName].Item1))
                     {
                         PerformResolutionChange(screen, _windowsResolutionSettings[screen.DeviceName].Item1);
                     }
 
-                    _amdAdapter.SetSaturationOnAllDisplays(_vibranceInfo.userVibranceSettingDefault);
+                    //apply Windows saturation
+                    RestoreWindowsVibranceLevel();
                 }
+            }
+        }
+
+        // Same restore run from both the OnWinEventHook restore branch above and HandleDvcExit, in
+        // place of the old unconditional SetSaturationOnAllDisplays(...) both used to call
+        // regardless of affectPrimaryMonitorOnly (issue #60/#36 on AMD: the flag was never
+        // consulted here, so a second monitor's level was stomped on every restore and every exit
+        // even with the checkbox on).
+        private void RestoreWindowsVibranceLevel()
+        {
+            // A no-op before SetVibranceWindowsLevel has actually run once - see VibranceInfo's
+            // isWindowsLevelKnown comment and NvidiaDynamicVibranceProxy's matching guard.
+            if (!_vibranceInfo.isWindowsLevelKnown)
+            {
+                return;
+            }
+
+            if (!_vibranceInfo.affectPrimaryMonitorOnly)
+            {
+                _amdAdapter.SetSaturationOnAllDisplays(_vibranceInfo.userVibranceSettingDefault);
+                VibranceRestoreHelper.ClearAllGameLevelRecords();
+                return;
+            }
+
+            // IAmdAdapter has no read-back to confirm a write landed, unlike NVIDIA's
+            // equalsDVCLevel/setDVCLevel pair - so, unlike NvidiaDynamicVibranceProxy's
+            // RestoreOneDisplay, every target is written unconditionally and cleared
+            // unconditionally, unable to tell "already correct" from "just fixed" or to retry a
+            // failure that has no way to be observed here.
+            List<string> targets = VibranceRestoreHelper.ComposeRestoreTargets(true, VibranceRestoreHelper.GetPrimaryDeviceName());
+            foreach (string deviceName in targets)
+            {
+                _amdAdapter.SetSaturationOnDisplay(_vibranceInfo.userVibranceSettingDefault, deviceName);
+                VibranceRestoreHelper.ClearGameLevelRecord(deviceName);
             }
         }
 

--- a/vibrance.GUI/NVIDIA/NvidiaDynamicVibranceProxy.cs
+++ b/vibrance.GUI/NVIDIA/NvidiaDynamicVibranceProxy.cs
@@ -13,6 +13,35 @@ using vibrance.GUI.common;
 
 namespace vibrance.GUI.NVIDIA
 {
+    // The seam between the vibrance apply/restore logic below and the actual NVIDIA driver.
+    // RealNvidiaVibranceDevice (nested at the bottom of NvidiaDynamicVibranceProxy) is the only
+    // production implementation; VibranceRestoreFixture supplies a fake that records every
+    // (handle, level) it is asked to write, so the apply/restore logic - the part that carried
+    // issues #60/#36 (a second monitor reset on every launch), #144 (vibrance surviving the game
+    // closing) and #95 (vibrance surviving an alt-tab to another monitor) - can be driven through
+    // real cycles, including forced failures, without a GPU.
+    internal interface INvidiaVibranceDevice
+    {
+        // hWnd is ref, matching isWindowActive's own HWND* signature, not IntPtr-by-value: the
+        // pre-existing call site ("IntPtr processHandle = e.Handle; ... isWindowActive(ref
+        // processHandle); ... Screen.FromHandle(processHandle)") already relies on whatever this
+        // native call may write back into the handle it was given determining which screen the
+        // rest of that branch resolves to. Taking hWnd by value here would silently drop that and
+        // risk changing which screen a restore reasons about - exactly the kind of behaviour this
+        // fix is not supposed to touch.
+        bool IsWindowActive(ref IntPtr hWnd);
+
+        // getAssociatedNvidiaDisplayHandle. -1 when NvAPI cannot name deviceName's display; never
+        // called with a null or empty deviceName.
+        int TryResolveDisplayHandle(string deviceName);
+
+        // equalsDVCLevel.
+        bool IsAtLevel(int displayHandle, int level);
+
+        // setDVCLevel.
+        bool SetLevel(int displayHandle, int level);
+    }
+
     class NvidiaDynamicVibranceProxy : IVibranceProxy
     {
         #region DllImports
@@ -134,6 +163,19 @@ namespace vibrance.GUI.NVIDIA
         private WinEventHook _hook;
         private static Screen _gameScreen;
 
+        // The only production INvidiaVibranceDevice. Not readonly - ResetForTests below swaps it
+        // for a fake so VibranceRestoreFixture can drive ApplyGameVibranceLevel/
+        // RestoreWindowsVibranceLevel (and, through them, OnWinEventHook itself, which is private
+        // static and so reachable by reflection with no instance at all) without ever calling
+        // initializeLibrary() or touching a real GPU.
+        private static INvidiaVibranceDevice _device = new RealNvidiaVibranceDevice();
+
+        // Suppresses repeat log calls for a display that is failing to resolve or failing to
+        // write, on either the apply or the restore path - one set per device, cleared on any
+        // success, so a foreground-change storm against a broken display does not redo a
+        // synchronous log write on the UI thread on every single event.
+        private static readonly HashSet<string> _loggedDisplayFailures = new HashSet<string>();
+
         public NvidiaDynamicVibranceProxy(List<ApplicationSetting> savedApplicationSettings, Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> currentWindowsResolutionSettings)
         {
             try
@@ -155,12 +197,12 @@ namespace vibrance.GUI.NVIDIA
             catch (Exception ex)
             {
                 MessageBox.Show(ex.ToString());
-                DialogResult result = MessageBox.Show(NvidiaDynamicVibranceProxy.NvapiErrorInitFailed, "vibranceGUI Error", 
+                DialogResult result = MessageBox.Show(NvidiaDynamicVibranceProxy.NvapiErrorInitFailed, "vibranceGUI Error",
                     MessageBoxButtons.OKCancel, MessageBoxIcon.Information);
                 if (result == DialogResult.OK)
                 {
                     Process.Start(GuideLink);
-                }                
+                }
             }
         }
 
@@ -177,9 +219,9 @@ namespace vibrance.GUI.NVIDIA
                     NvSystemType systemType = getGpuSystemType(gpuHandle);
                     if (systemType == NvSystemType.NvSystemTypeUnknown)
                     {
-                        MessageBox.Show(NvidiaDynamicVibranceProxy.NvapiErrorSystypeUnknown, "vibranceGUI Error", 
+                        MessageBox.Show(NvidiaDynamicVibranceProxy.NvapiErrorSystypeUnknown, "vibranceGUI Error",
                             MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        _vibranceInfo.isInitialized = false; 
+                        _vibranceInfo.isInitialized = false;
                         return;
                     }
                 }
@@ -192,16 +234,24 @@ namespace vibrance.GUI.NVIDIA
             char[] sz = new char[64];
             getGpuName(gpuHandles, buffer);
             _vibranceInfo.szGpuName = buffer.ToString();
-            _vibranceInfo.defaultHandle = enumerateNvidiaDisplayHandle(0);
 
-            NvDisplayDvcInfo info = new NvDisplayDvcInfo();
-            if (getDVCInfo(ref info, _vibranceInfo.defaultHandle))
-            {
-                if (info.currentLevel != _vibranceInfo.userVibranceSettingDefault)
-                {
-                    setDVCLevel(_vibranceInfo.defaultHandle, _vibranceInfo.userVibranceSettingDefault);
-                }
-            }
+            // No DVC write here anymore (issue #60/#36). This used to do
+            // "_vibranceInfo.defaultHandle = enumerateNvidiaDisplayHandle(0);" - an arbitrary
+            // display, not necessarily the primary and not one affectPrimaryMonitorOnly was ever
+            // consulted for - then write _vibranceInfo.userVibranceSettingDefault to it via
+            // getDVCInfo/setDVCLevel. But SetVibranceWindowsLevel(...) has not been called yet at
+            // this point in startup (it runs later, from VibranceGUI.cs's backgroundWorker_DoWork,
+            // after that method's own "while (!this.IsHandleCreated) Thread.Sleep(500);" wait), so
+            // userVibranceSettingDefault was still VibranceInfo's struct default of 0 - every
+            // launch stamped 0 onto whatever display handle 0 happened to name, resetting a second
+            // monitor's level even though it was never a game's screen and affectPrimaryMonitorOnly
+            // was never asked about it.
+            // A foreground event CAN still land on the hook before SetVibranceWindowsLevel runs
+            // (the app's own window appearing is one) - RestoreWindowsVibranceLevel's
+            // isWindowsLevelKnown guard (see VibranceInfo) makes that a no-op instead of writing
+            // the still-unknown level, rather than trying to make it unreachable. The desktop scope
+            // then receives the real, saved Windows level on the first non-game foreground event
+            // after SetVibranceWindowsLevel has actually run.
 
             _vibranceInfo.isInitialized = true;
         }
@@ -212,15 +262,18 @@ namespace vibrance.GUI.NVIDIA
             {
                 ApplicationSetting applicationSetting = _applicationSettings.FirstOrDefault(x => string.Equals(x.Name, e.ProcessName, StringComparison.OrdinalIgnoreCase));
                 if (applicationSetting != null)
-                {                  
-                    int displayHandle = GetApplicationDisplayHandle(e.Handle);
+                {
+                    Screen screen = Screen.FromHandle(e.Handle);
+                    int displayHandle = _device.TryResolveDisplayHandle(screen.DeviceName);
+                    // 0 is a null NvDisplayHandle, same as the -1 "not found" - InitializeProxy
+                    // used to treat a gpuHandle of 0 the same way. Neither one is a display this
+                    // can meaningfully write to.
                     //test if changing the vibrance value is needed
-                    if (displayHandle != -1 && !equalsDVCLevel(displayHandle, applicationSetting.IngameLevel))
+                    if (displayHandle != -1 && displayHandle != 0 && !_device.IsAtLevel(displayHandle, applicationSetting.IngameLevel))
                     {
                         //test if a resolution change is needed
-                        Screen screen = Screen.FromHandle(e.Handle);
-                        if (_vibranceInfo.neverChangeResolution == false && 
-                            applicationSetting.IsResolutionChangeNeeded && 
+                        if (_vibranceInfo.neverChangeResolution == false &&
+                            applicationSetting.IsResolutionChangeNeeded &&
                             IsResolutionChangeNeeded(screen, applicationSetting.ResolutionSettings) &&
                             _windowsResolutionSettings.ContainsKey(screen.DeviceName) &&
                             _windowsResolutionSettings[screen.DeviceName].Item2.Contains(applicationSetting.ResolutionSettings))
@@ -228,49 +281,56 @@ namespace vibrance.GUI.NVIDIA
                             PerformResolutionChange(screen, applicationSetting.ResolutionSettings);
                         }
                         _gameScreen = screen;
-                        _vibranceInfo.defaultHandle = displayHandle;
-                        setDVCLevel(_vibranceInfo.defaultHandle, applicationSetting.IngameLevel);
+                        if (ApplyGameVibranceLevel(_device, screen.DeviceName, applicationSetting.IngameLevel))
+                        {
+                            VibranceRestoreHelper.RecordGameLevelApplied(screen.DeviceName);
+                        }
                     }
                 }
                 else
                 {
                     IntPtr processHandle = e.Handle;
 
-                    if (!isWindowActive(ref processHandle))
+                    if (!_device.IsWindowActive(ref processHandle))
                         return;
-                    
+
                     //test if a resolution change is needed
                     Screen currentScreen = Screen.FromHandle(processHandle);
-                    if (_vibranceInfo.neverChangeResolution == false && 
-                        _gameScreen != null && 
-                        _gameScreen.Equals(currentScreen) && 
+                    if (_vibranceInfo.neverChangeResolution == false &&
+                        _gameScreen != null &&
+                        _gameScreen.Equals(currentScreen) &&
                         _windowsResolutionSettings.ContainsKey(currentScreen.DeviceName) &&
                         IsResolutionChangeNeeded(currentScreen, _windowsResolutionSettings[currentScreen.DeviceName].Item1))
                     {
                         PerformResolutionChange(currentScreen, _windowsResolutionSettings[currentScreen.DeviceName].Item1);
                     }
 
-                    //test if changing the vibrance value is needed
-                    if (_vibranceInfo.affectPrimaryMonitorOnly && !equalsDVCLevel(_vibranceInfo.defaultHandle, _vibranceInfo.userVibranceSettingDefault))
-                    {
-                        if(_gameScreen != null && !_gameScreen.DeviceName.Equals(currentScreen.DeviceName))
-                        {
-                            return;
-                        }
-
-                        setDVCLevel(_vibranceInfo.defaultHandle, _vibranceInfo.userVibranceSettingDefault);
-                    }
-                    else if (!_vibranceInfo.affectPrimaryMonitorOnly && !_vibranceInfo.displayHandles.TrueForAll(handle => equalsDVCLevel(handle, _vibranceInfo.userVibranceSettingDefault)))
-                    {
-                        _vibranceInfo.displayHandles.ForEach(handle => setDVCLevel(handle, _vibranceInfo.userVibranceSettingDefault));
-                    }
+                    // Deliberately does NOT scope this to currentScreen (issues #95, #144):
+                    // restoring only "the screen that currently has focus" left a game's monitor
+                    // saturated after an alt-tab to another monitor while the game was still open,
+                    // and left it saturated forever after the game exited, if the desktop's
+                    // foreground never happened to land back on that same screen first.
+                    // RestoreWindowsVibranceLevel instead restores every display this application
+                    // actually holds a game level on, plus the primary (see
+                    // VibranceRestoreHelper.ComposeRestoreTargets), regardless of where the
+                    // foreground currently is. This replaces the pre-fix gate:
+                    // "if (_vibranceInfo.affectPrimaryMonitorOnly && !equalsDVCLevel(defaultHandle,
+                    // userVibranceSettingDefault)) { if (_gameScreen != null &&
+                    // !_gameScreen.DeviceName.Equals(currentScreen.DeviceName)) { return; }
+                    // setDVCLevel(...); } else if (...) { ... }" - added in 2017 to stop a game
+                    // losing its vibrance when the user clicked something on a second screen while
+                    // the game was still visible. It could only express "the mouse is elsewhere",
+                    // never "the game is still running", which is what #95/#144 cost.
+                    RestoreWindowsVibranceLevel(_device, _vibranceInfo.affectPrimaryMonitorOnly,
+                        VibranceRestoreHelper.GetPrimaryDeviceName(), _vibranceInfo.displayHandles,
+                        _vibranceInfo.userVibranceSettingDefault, _vibranceInfo.isWindowsLevelKnown);
                 }
             }
         }
 
         private static bool IsResolutionChangeNeeded(Screen screen, ResolutionModeWrapper resolutionSettings)
         {
-            Devmode mode;            
+            Devmode mode;
             if (resolutionSettings != null && ResolutionHelper.GetCurrentResolutionSettings(out mode, screen.DeviceName) && !resolutionSettings.Equals(mode))
             {
                 return true;
@@ -296,22 +356,207 @@ namespace vibrance.GUI.NVIDIA
             }
         }
 
-        private static int GetApplicationDisplayHandle(IntPtr hWnd)
+        /// <summary>
+        /// Writes ingameLevel to gameDeviceName's NVIDIA display, unless it is already there.
+        /// Returns true only when the write actually landed - only then may the caller record the
+        /// display as owing a restore. Returns true without writing anything when the display is
+        /// already at ingameLevel. Does not throw on a resolve failure or a failed write - both are
+        /// logged once and simply skipped. The underlying P/Invokes themselves are not guarded here
+        /// and can still throw, exactly as they could before this seam existed.
+        /// </summary>
+        internal static bool ApplyGameVibranceLevel(INvidiaVibranceDevice device, string gameDeviceName, int ingameLevel)
         {
-            if (hWnd != IntPtr.Zero)
+            int displayHandle = device.TryResolveDisplayHandle(gameDeviceName);
+            if (displayHandle == -1 || displayHandle == 0)
             {
-                Screen primaryScreen = System.Windows.Forms.Screen.FromHandle(hWnd);
-                if (primaryScreen != null)
-                {
-                    string deviceName = primaryScreen.DeviceName;
-                    GCHandle handle = GCHandle.Alloc(deviceName, GCHandleType.Pinned);
-                    int id = getAssociatedNvidiaDisplayHandle(deviceName, deviceName.Length);
-                    handle.Free();
+                // 0 is a null NvDisplayHandle. Never fall back to enumerateNvidiaDisplayHandle(0):
+                // that arbitrary-display fallback is exactly what issue #60/#36 was.
+                LogDisplayFailureOnce(gameDeviceName, string.Format(
+                    "Could not resolve an NVIDIA display handle for screen {0}, skipping its ingame vibrance apply", gameDeviceName));
+                return false;
+            }
 
-                    return id;
+            if (device.IsAtLevel(displayHandle, ingameLevel))
+            {
+                ClearDisplayFailureLog(gameDeviceName);
+                return true;
+            }
+
+            if (device.SetLevel(displayHandle, ingameLevel))
+            {
+                ClearDisplayFailureLog(gameDeviceName);
+                return true;
+            }
+
+            LogDisplayFailureOnce(gameDeviceName, string.Format(
+                "Failed to set the ingame vibrance level for screen {0}", gameDeviceName));
+            return false;
+        }
+
+        /// <summary>
+        /// Writes windowsLevel to every display owing a restore (VibranceRestoreHelper's
+        /// work-list), plus the display the Windows Vibrance Level itself owns, and nothing else -
+        /// deliberately not scoped to whichever screen currently has focus (see the call site in
+        /// OnWinEventHook for why: issues #95 and #144). A no-op while isWindowsLevelKnown is
+        /// false (see VibranceInfo) - windowsLevel is meaningless before SetVibranceWindowsLevel
+        /// has actually run once, and writing it anyway would re-introduce the arbitrary-0 write
+        /// InitializeProxy used to make (issue #60/#36) at one remove. allDisplayHandles is
+        /// consulted only when affectPrimaryMonitorOnly is false, in which case this preserves the
+        /// pre-existing all-displays behaviour exactly (skipping any -1/0 entry EnumerateDisplayHandles
+        /// could still hand back) and then drops the whole work-list - that branch never wrote
+        /// through it in the first place.
+        ///
+        /// Per display in the affectPrimaryMonitorOnly branch: unresolvable (-1 or 0) leaves the
+        /// display on the work-list for a single P/Invoke (TryResolveDisplayHandle) so the next
+        /// foreground event retries it. A display that resolves but fails to write costs three
+        /// P/Invokes on that same retry - resolve, the IsAtLevel read-back, then SetLevel - not
+        /// one; IsAtLevel only saves a call for a display that turns out to already be correct, not
+        /// for one that is genuinely failing to write. A display already at windowsLevel is drained
+        /// without ever calling SetLevel.
+        /// </summary>
+        internal static void RestoreWindowsVibranceLevel(INvidiaVibranceDevice device, bool affectPrimaryMonitorOnly,
+            string primaryDeviceName, IList<int> allDisplayHandles, int windowsLevel, bool isWindowsLevelKnown)
+        {
+            if (!isWindowsLevelKnown)
+            {
+                return;
+            }
+
+            if (!affectPrimaryMonitorOnly)
+            {
+                if (allDisplayHandles != null && !AllDisplaysAtLevel(device, allDisplayHandles, windowsLevel))
+                {
+                    for (int i = 0; i < allDisplayHandles.Count; i++)
+                    {
+                        int handle = allDisplayHandles[i];
+                        if (handle == -1 || handle == 0)
+                        {
+                            continue;
+                        }
+                        device.SetLevel(handle, windowsLevel);
+                    }
+                }
+                VibranceRestoreHelper.ClearAllGameLevelRecords();
+                return;
+            }
+
+            List<string> targets = VibranceRestoreHelper.ComposeRestoreTargets(true, primaryDeviceName);
+            foreach (string deviceName in targets)
+            {
+                RestoreOneDisplay(device, deviceName, windowsLevel);
+            }
+        }
+
+        private static bool AllDisplaysAtLevel(INvidiaVibranceDevice device, IList<int> displayHandles, int level)
+        {
+            for (int i = 0; i < displayHandles.Count; i++)
+            {
+                int handle = displayHandles[i];
+                if (handle == -1 || handle == 0)
+                {
+                    continue;
+                }
+                if (!device.IsAtLevel(handle, level))
+                {
+                    return false;
                 }
             }
-            return -1;
+            return true;
+        }
+
+        private static void RestoreOneDisplay(INvidiaVibranceDevice device, string deviceName, int windowsLevel)
+        {
+            int displayHandle = device.TryResolveDisplayHandle(deviceName);
+            if (displayHandle == -1 || displayHandle == 0)
+            {
+                LogDisplayFailureOnce(deviceName, string.Format(
+                    "Could not resolve an NVIDIA display handle for screen {0}, its Windows vibrance level restore will retry on the next foreground change", deviceName));
+                return; // stays on the work-list - see VibranceRestoreHelper.
+            }
+
+            if (device.IsAtLevel(displayHandle, windowsLevel))
+            {
+                VibranceRestoreHelper.ClearGameLevelRecord(deviceName);
+                ClearDisplayFailureLog(deviceName);
+                return;
+            }
+
+            if (device.SetLevel(displayHandle, windowsLevel))
+            {
+                VibranceRestoreHelper.ClearGameLevelRecord(deviceName);
+                ClearDisplayFailureLog(deviceName);
+            }
+            else
+            {
+                LogDisplayFailureOnce(deviceName, string.Format(
+                    "Failed to restore the Windows vibrance level for screen {0}, it will retry on the next foreground change", deviceName));
+            }
+        }
+
+        private static void LogDisplayFailureOnce(string deviceName, string message)
+        {
+            if (_loggedDisplayFailures.Add(deviceName))
+            {
+                Program.LogSafely(message);
+            }
+        }
+
+        private static void ClearDisplayFailureLog(string deviceName)
+        {
+            _loggedDisplayFailures.Remove(deviceName);
+        }
+
+        // Exists for VibranceRestoreFixture only - swaps out every static field OnWinEventHook and
+        // the apply/restore methods above depend on, so a check can run the real, private static
+        // OnWinEventHook (reflection is the only seam into it; it takes no instance) or the
+        // Apply/RestoreWindowsVibranceLevel overloads directly, entirely against a fake device and
+        // fake settings, with no call to the constructor and so no initializeLibrary() and no real
+        // GPU touched. Mirrors VibranceRestoreHelper.ResetForTests.
+        internal static void ResetForTests(INvidiaVibranceDevice device, VibranceInfo vibranceInfo,
+            List<ApplicationSetting> applicationSettings)
+        {
+            _device = device ?? new RealNvidiaVibranceDevice();
+            _vibranceInfo = vibranceInfo;
+            _applicationSettings = applicationSettings ?? new List<ApplicationSetting>();
+            _gameScreen = null;
+            _loggedDisplayFailures.Clear();
+            VibranceRestoreHelper.ResetForTests();
+        }
+
+        // The production INvidiaVibranceDevice: the four native calls below against the real
+        // vibranceDLL.dll, exactly as OnWinEventHook/GetApplicationDisplayHandle called them
+        // directly before this seam existed.
+        private class RealNvidiaVibranceDevice : INvidiaVibranceDevice
+        {
+            public bool IsWindowActive(ref IntPtr hWnd)
+            {
+                return isWindowActive(ref hWnd);
+            }
+
+            public int TryResolveDisplayHandle(string deviceName)
+            {
+                if (string.IsNullOrEmpty(deviceName))
+                {
+                    return -1;
+                }
+                // The marshaller (CharSet.Ansi on the DllImport above) copies deviceName into its
+                // own native ANSI buffer for the duration of this one call and frees it afterward -
+                // there is nothing here for a caller-side GCHandle to protect. The pin the old
+                // GetApplicationDisplayHandle used (GCHandle.Alloc(deviceName,
+                // GCHandleType.Pinned)) pinned a managed string that the marshaller was never going
+                // to touch directly in the first place.
+                return getAssociatedNvidiaDisplayHandle(deviceName, deviceName.Length);
+            }
+
+            public bool IsAtLevel(int displayHandle, int level)
+            {
+                return equalsDVCLevel(displayHandle, level);
+            }
+
+            public bool SetLevel(int displayHandle, int level)
+            {
+                return setDVCLevel(displayHandle, level);
+            }
         }
 
         public void SetApplicationSettings(List<ApplicationSetting> refApplicationSettings)
@@ -331,6 +576,7 @@ namespace vibrance.GUI.NVIDIA
         public void SetVibranceWindowsLevel(int vibranceWindowsLevel)
         {
             _vibranceInfo.userVibranceSettingDefault = vibranceWindowsLevel;
+            _vibranceInfo.isWindowsLevelKnown = true;
         }
 
         public void SetVibranceIngameLevel(int vibranceIngameLevel)
@@ -367,12 +613,14 @@ namespace vibrance.GUI.NVIDIA
 
         public void HandleDvcExit()
         {
-            if (_vibranceInfo.affectPrimaryMonitorOnly)
-            {
-                setDVCLevel(_vibranceInfo.defaultHandle, _vibranceInfo.userVibranceSettingDefault);
-            }
-            else if (!_vibranceInfo.displayHandles.TrueForAll(handle => equalsDVCLevel(handle, _vibranceInfo.userVibranceSettingDefault)))
-                _vibranceInfo.displayHandles.ForEach(handle => setDVCLevel(handle, _vibranceInfo.userVibranceSettingDefault));
+            // Same restore RestoreWindowsVibranceLevel already does on every non-game foreground
+            // event (issue #144: vibrance used to survive the game closing because this used to
+            // write only through the hijacked _vibranceInfo.defaultHandle - the game's own display,
+            // if the apply branch had ever run - instead of every display actually holding a game
+            // level).
+            RestoreWindowsVibranceLevel(_device, _vibranceInfo.affectPrimaryMonitorOnly,
+                VibranceRestoreHelper.GetPrimaryDeviceName(), _vibranceInfo.displayHandles,
+                _vibranceInfo.userVibranceSettingDefault, _vibranceInfo.isWindowsLevelKnown);
         }
     }
 }

--- a/vibrance.GUI/Program.cs
+++ b/vibrance.GUI/Program.cs
@@ -19,6 +19,7 @@ namespace vibrance.GUI
         private const string ErrorGraphicsAdapterUnknown = "Failed to determine your Graphic GraphicsAdapter type (NVIDIA/AMD). Make sure you have installed a proper GPU driver. Intel laptops are not supported as stated on the website. When installing your GPU driver did not work, please contact @juvlarN at twitter. Press Yes to open twitter in your browser now. Error: ";
         private const string ErrorGraphicsAdapterAmbiguous = "Both NVIDIA and AMD graphic drivers have been found on your system. This can happen when you recently switched your graphic card and did not uninstall the old drivers. Make sure to uninstall unused graphic drivers to keep your system safe and stable. Use the program \"Display Driver Uninstaller\" to uninstall your old drivers!\n\nPress Yes to open \"Display Driver Uninstaller\" download website now.\nPress No to quit vibranceGUI.";
         private const string MessageBoxCaption = "vibranceGUI Error";
+        private const string VibranceSelfTestMessageBoxCaption = "vibranceGUI vibrance restore self test";
 
         [STAThread]
         static void Main(string[] args)
@@ -33,6 +34,21 @@ namespace vibrance.GUI
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            // Placed before NativeMethods.SetDllDirectory/GraphicsAdapterHelper.GetAdapter() below
+            // on purpose: VibranceRestoreFixture only ever drives the NVIDIA/AMD apply and restore
+            // logic through INvidiaVibranceDevice/IAmdAdapter fakes, so it needs no GPU driver and
+            // must stay runnable on a machine (or a build agent) that GetAdapter() cannot resolve
+            // and would exit from. There is deliberately no hardware variant of this self test, and
+            // there must never be one - a fixture that could change a real display's vibrance would
+            // be the exact bug issues #60/#36/#144/#95 are about.
+            if (args.Contains("--selftest-vibrance"))
+            {
+                MessageBox.Show(string.Join(Environment.NewLine, VibranceRestoreFixture.Run().ToArray()),
+                    VibranceSelfTestMessageBoxCaption, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
             NativeMethods.SetDllDirectory(CommonUtils.GetVibrance_GUI_AppDataPath());
 
             GraphicsAdapter adapter = GraphicsAdapterHelper.GetAdapter();

--- a/vibrance.GUI/Program.cs
+++ b/vibrance.GUI/Program.cs
@@ -43,8 +43,8 @@ namespace vibrance.GUI
                 Func<List<ApplicationSetting>, Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>, IVibranceProxy> getProxy = (x, y) => new AmdDynamicVibranceProxy(Environment.Is64BitOperatingSystem
                     ? new AmdAdapter64()
                     : (IAmdAdapter)new AmdAdapter32(), x, y);
-                vibranceGui = new VibranceGUI(getProxy, 
-                    100, 
+                vibranceGui = new VibranceGUI(getProxy,
+                    100,
                     0,
                     300,
                     100,
@@ -80,7 +80,7 @@ namespace vibrance.GUI
             }
             else if(adapter == GraphicsAdapter.Ambiguous)
             {
-                if(MessageBox.Show(ErrorGraphicsAdapterAmbiguous, MessageBoxCaption, MessageBoxButtons.YesNo, 
+                if(MessageBox.Show(ErrorGraphicsAdapterAmbiguous, MessageBoxCaption, MessageBoxButtons.YesNo,
                     MessageBoxIcon.Error) == DialogResult.Yes)
                 {
                     System.Diagnostics.Process.Start("http://www.guru3d.com/files-details/display-driver-uninstaller-download.html");
@@ -96,6 +96,24 @@ namespace vibrance.GUI
             Application.Run(vibranceGui);
 
             GC.KeepAlive(mutex);
+        }
+
+        // Internal rather than private: the vibrance restore path (see
+        // NVIDIA\NvidiaDynamicVibranceProxy.cs's LogDisplayFailureOnce, reached from the
+        // WINEVENT_OUTOFCONTEXT foreground-change callback) reuses this so a broken log write
+        // (e.g. File.AppendText failing, the log file being locked by another process) cannot
+        // itself throw an exception back across that native callback frame. VibranceGUI.Log's own
+        // File.AppendText calls are otherwise unguarded.
+        internal static void LogSafely(string message)
+        {
+            try
+            {
+                VibranceGUI.Log(message);
+            }
+            catch (Exception)
+            {
+                // Logging must never be the reason a foreground event handler throws.
+            }
         }
     }
 }

--- a/vibrance.GUI/common/Definitions.cs
+++ b/vibrance.GUI/common/Definitions.cs
@@ -9,7 +9,13 @@ namespace vibrance.GUI.common
     {
         public bool isInitialized;
         public int activeOutput;
-        public int defaultHandle;
+        // False until SetVibranceWindowsLevel has actually been called - true from construction
+        // through the window between the proxy subscribing OnWinEventHook and VibranceGUI.cs's
+        // backgroundWorker_DoWork reaching SetVibranceWindowsLevel (it waits on
+        // "while (!this.IsHandleCreated) Thread.Sleep(500);" first). Both vendors' restore paths
+        // treat a foreground event landing in that window as a no-op instead of writing
+        // userVibranceSettingDefault's still-zero struct default.
+        public bool isWindowsLevelKnown;
         public int userVibranceSettingDefault;
         public int userVibranceSettingActive;
         public String szGpuName;

--- a/vibrance.GUI/common/VibranceGUI.Designer.cs
+++ b/vibrance.GUI/common/VibranceGUI.Designer.cs
@@ -152,7 +152,7 @@
             this.checkBoxPrimaryMonitorOnly.TabIndex = 15;
             this.checkBoxPrimaryMonitorOnly.Text = "Affect Primary Monitor only";
             this.toolTip.SetToolTip(this.checkBoxPrimaryMonitorOnly, "When checking this, VibranceGUI will only change vibrance values on your primary " +
-        "monitor.");
+        "monitor and the monitor the game is running on - no others.");
             this.checkBoxPrimaryMonitorOnly.UseVisualStyleBackColor = true;
             this.checkBoxPrimaryMonitorOnly.CheckedChanged += new System.EventHandler(this.checkBoxPrimaryMonitorOnly_CheckedChanged);
             // 

--- a/vibrance.GUI/common/VibranceRestoreFixture.cs
+++ b/vibrance.GUI/common/VibranceRestoreFixture.cs
@@ -1,0 +1,1094 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using vibrance.GUI.AMD;
+using vibrance.GUI.AMD.vendor;
+using vibrance.GUI.NVIDIA;
+
+namespace vibrance.GUI.common
+{
+    /// <summary>
+    /// Regression coverage for the vibrance restore fix: issues #60/#36 ("Affect Primary Monitor
+    /// only" resetting a second monitor's level on every launch or restore) and #144/#95 (vibrance
+    /// surviving the game closing, or an alt-tab to another monitor, because restore was scoped to
+    /// whichever screen currently has focus instead of to whatever this application actually
+    /// changed). No GUI, no live GPU driver - the NVIDIA half is driven entirely through
+    /// INvidiaVibranceDevice and NvidiaDynamicVibranceProxy's ResetForTests seam, and the AMD half
+    /// through IAmdAdapter, a fake implementation of the same interface AmdDynamicVibranceProxy's
+    /// constructor already takes. Run by vibrance.GUI.exe --selftest-vibrance.
+    ///
+    /// Deliberately has no hardware variant and must never grow one: a fixture that actually
+    /// changed a real display's vibrance would be changing exactly the state these four issues are
+    /// about, on whatever machine happens to run the regression suite.
+    /// </summary>
+    public static class VibranceRestoreFixture
+    {
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetDesktopWindow();
+
+        public static List<string> Run()
+        {
+            Checklist checklist = new Checklist();
+            checklist.Lines.Add("vibranceGUI vibrance restore self test");
+            checklist.Lines.Add(string.Empty);
+
+            RunPureChecks(checklist);
+            RunNvidiaChecks(checklist);
+            RunAmdChecks(checklist);
+
+            checklist.Lines.Add(string.Empty);
+            checklist.Lines.Add(string.Format("PASSED {0}/{1}", checklist.Passed, checklist.Total));
+            return checklist.Lines;
+        }
+
+        // ------------------------------------------------------------------
+        // Pure - VibranceRestoreHelper.ComposeRestoreTargets, no fakes at all.
+        // ------------------------------------------------------------------
+
+        private static void RunPureChecks(Checklist checklist)
+        {
+            checklist.Lines.Add("ComposeRestoreTargets (pure):");
+
+            CheckComposeAppendsPrimaryOnce(checklist);
+            CheckComposeDoesNotDuplicatePrimaryAlreadyOnWorkList(checklist);
+            CheckComposeToleratesMissingPrimary(checklist);
+            CheckComposeAppendsPrimaryEvenWithAnEmptyWorkList(checklist);
+            CheckComposeNeverAppendsPrimaryWithFlagOff(checklist);
+
+            checklist.Lines.Add(string.Empty);
+        }
+
+        // V1. Mutation this guards: don't append the primary at all.
+        private static void CheckComposeAppendsPrimaryOnce(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+            VibranceRestoreHelper.RecordGameLevelApplied("D2");
+            VibranceRestoreHelper.RecordGameLevelApplied("D3");
+
+            List<string> targets = VibranceRestoreHelper.ComposeRestoreTargets(true, "D1");
+
+            checklist.Check(SequenceEqual(targets, new List<string> { "D2", "D3", "D1" }),
+                string.Format("V1: work-list {{D2,D3}} + primary D1, flag on -> [D2,D3,D1], got [{0}]",
+                    string.Join(",", targets)));
+        }
+
+        // V2. Mutation this guards: append the primary unconditionally, even when it duplicates a
+        // work-list entry.
+        private static void CheckComposeDoesNotDuplicatePrimaryAlreadyOnWorkList(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+            VibranceRestoreHelper.RecordGameLevelApplied("D1");
+
+            List<string> targets = VibranceRestoreHelper.ComposeRestoreTargets(true, "D1");
+
+            checklist.Check(targets.Count == 1 && targets[0] == "D1",
+                string.Format("V2: work-list {{D1}} + primary D1 -> [D1] (length 1, no duplicate), got [{0}]",
+                    string.Join(",", targets)));
+        }
+
+        // V3. Mutation this guards: append primaryDeviceName unguarded, even when it is null or
+        // empty.
+        private static void CheckComposeToleratesMissingPrimary(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+            VibranceRestoreHelper.RecordGameLevelApplied("D2");
+
+            List<string> nullPrimaryTargets = VibranceRestoreHelper.ComposeRestoreTargets(true, null);
+            List<string> emptyPrimaryTargets = VibranceRestoreHelper.ComposeRestoreTargets(true, string.Empty);
+
+            bool ok = SequenceEqual(nullPrimaryTargets, new List<string> { "D2" }) &&
+                SequenceEqual(emptyPrimaryTargets, new List<string> { "D2" });
+            checklist.Check(ok, string.Format(
+                "V3: a null or empty primary leaves the work-list alone, no null/empty entry - got null=[{0}], empty=[{1}]",
+                string.Join(",", nullPrimaryTargets), string.Join(",", emptyPrimaryTargets)));
+        }
+
+        // V4. Mutation this guards: return early (an empty list) when the work-list itself is
+        // empty, skipping the primary append.
+        private static void CheckComposeAppendsPrimaryEvenWithAnEmptyWorkList(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+
+            List<string> targets = VibranceRestoreHelper.ComposeRestoreTargets(true, "D1");
+
+            checklist.Check(targets.Count == 1 && targets[0] == "D1",
+                string.Format("V4: empty work-list + primary D1, flag on -> [D1], got [{0}]", string.Join(",", targets)));
+        }
+
+        // V5. Mutation this guards: append the primary regardless of affectPrimaryMonitorOnly.
+        private static void CheckComposeNeverAppendsPrimaryWithFlagOff(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+            VibranceRestoreHelper.RecordGameLevelApplied("D2");
+
+            List<string> targets = VibranceRestoreHelper.ComposeRestoreTargets(false, "D1");
+
+            checklist.Check(SequenceEqual(targets, new List<string> { "D2" }),
+                string.Format("V5: flag off -> work-list alone, primary never appended, got [{0}]", string.Join(",", targets)));
+        }
+
+        // ------------------------------------------------------------------
+        // NVIDIA - ApplyGameVibranceLevel/RestoreWindowsVibranceLevel via ResetForTests + a fake
+        // device that records every (handle, level) it is asked to write.
+        // ------------------------------------------------------------------
+
+        private static void RunNvidiaChecks(Checklist checklist)
+        {
+            checklist.Lines.Add("NVIDIA apply/restore (via NvidiaDynamicVibranceProxy's fixture seam):");
+
+            CheckNvidiaRestoreIgnoresDisplayHandlesWithFlagOn(checklist);
+            CheckNvidiaRestoreReachesEveryHeldDisplay(checklist);
+            CheckNvidiaRestoreDrainsWorkList(checklist);
+            CheckNvidiaRestoreRetriesFailedWrite(checklist);
+            CheckNvidiaRestoreGuardsUnresolvableHandle(checklist);
+            CheckNvidiaRestoreSkipsWriteWhenAlreadyAtLevel(checklist);
+            CheckNvidiaApplyOnlyRecordsALandedWrite(checklist);
+            CheckNvidiaRestoreAllDisplaysBranchUnchanged(checklist);
+            CheckNvidiaHandleDvcExitRestoresPrimaryGuardedByReadBack(checklist);
+            CheckNvidiaRestoreReachesRealCallSiteRegardlessOfGameScreen(checklist);
+            CheckNvidiaRestoreIsNoOpBeforeWindowsLevelKnown(checklist);
+            CheckNvidiaRestoreSkipsInvalidHandlesInAllDisplaysBranch(checklist);
+
+            checklist.Lines.Add(string.Empty);
+        }
+
+        // N13 (NB2). Mutation this guards: drop the "handle == -1 || handle == 0" skip from the
+        // flag-off branch's write loop and/or AllDisplaysAtLevel. EnumerateDisplayHandles's loop
+        // stops as soon as enumerateNvidiaDisplayHandle returns -1, but nothing filters a 0 it may
+        // still hand back as one of the earlier entries, so this is reachable in production, not
+        // hypothetical. N9 below seeds only valid handles and so cannot catch this on its own.
+        private static void CheckNvidiaRestoreSkipsInvalidHandlesInAllDisplaysBranch(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            List<int> displayHandles = new List<int> { -1, 0, 501 };
+            const int windowsLevel = 33;
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, false, null, displayHandles, windowsLevel, true);
+
+            bool onlyValidHandleWritten = device.SetLevelCalls.Count == 1 && device.SetLevelCalls[0] == 501;
+            checklist.Check(onlyValidHandleWritten, string.Format(
+                "N13: SetLevel is only called for the valid handle (501), never for -1 or 0, got [{0}]",
+                string.Join(",", device.SetLevelCalls)));
+        }
+
+        // N12 (NB1). Mutation this guards: drop the isWindowsLevelKnown guard from
+        // RestoreWindowsVibranceLevel (or otherwise let it write while the level is still
+        // unknown) - reopening the arbitrary-write window between the hook subscribing and
+        // SetVibranceWindowsLevel actually running (see VibranceInfo.isWindowsLevelKnown and
+        // InitializeProxy's comment). A fresh VibranceInfo()'s isWindowsLevelKnown is false (the
+        // struct default), matching real state before SetVibranceWindowsLevel has ever run once.
+        private static void CheckNvidiaRestoreIsNoOpBeforeWindowsLevelKnown(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string deviceName = "\\\\.\\DISPLAY_TESTONLY_N12";
+            const string primary = "\\\\.\\DISPLAY_TESTONLY_N12_PRIMARY";
+            VibranceRestoreHelper.RecordGameLevelApplied(deviceName);
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, primary, new List<int>(), 30, false);
+
+            checklist.Check(device.SetLevelCalls.Count == 0,
+                "N12: RestoreWindowsVibranceLevel is a no-op when isWindowsLevelKnown is false, even with a non-empty work-list and a primary target");
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 1,
+                "N12: the work-list is left untouched too - nothing was drained by a call that wrote nothing");
+        }
+
+        // N2 (#60/#36). Mutation this guards: take the pre-existing "displayHandles" all-displays
+        // branch even though affectPrimaryMonitorOnly is true.
+        private static void CheckNvidiaRestoreIgnoresDisplayHandlesWithFlagOn(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string deviceName = "\\\\.\\DISPLAY_TESTONLY_N2";
+            const int windowsLevel = 40;
+            VibranceRestoreHelper.RecordGameLevelApplied(deviceName);
+            string primaryDeviceName = VibranceRestoreHelper.GetPrimaryDeviceName();
+
+            // Three decoy handles that would be written if this fell back to the all-displays
+            // branch - it must not, with the flag on.
+            List<int> decoyDisplayHandles = new List<int> { 9001, 9002, 9003 };
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, primaryDeviceName, decoyDisplayHandles, windowsLevel, true);
+
+            checklist.Check(device.SetLevelCalls.Count == 2,
+                string.Format("N2: exactly two SetLevel calls (the work-list entry + the primary), got {0}", device.SetLevelCalls.Count));
+
+            bool noDecoyTouched = !device.SetLevelCalls.Contains(9001) && !device.SetLevelCalls.Contains(9002) && !device.SetLevelCalls.Contains(9003);
+            checklist.Check(noDecoyTouched, "N2: none of the three decoy displayHandles entries were written to");
+        }
+
+        // N3 (defaultHandle hijack). Mutation this guards: restore only the last-applied handle
+        // (the pre-fix "_vibranceInfo.defaultHandle = displayHandle" hijack), not every display
+        // actually holding a game level.
+        private static void CheckNvidiaRestoreReachesEveryHeldDisplay(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string d1 = "\\\\.\\DISPLAY_TESTONLY_N3_D1";
+            const string d2 = "\\\\.\\DISPLAY_TESTONLY_N3_D2";
+            const string d3 = "\\\\.\\DISPLAY_TESTONLY_N3_D3";
+            const int windowsLevel = 25;
+
+            VibranceRestoreHelper.RecordGameLevelApplied(d2);
+            VibranceRestoreHelper.RecordGameLevelApplied(d3);
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, d1, new List<int>(), windowsLevel, true);
+
+            int h1 = device.HandleFor(d1);
+            int h2 = device.HandleFor(d2);
+            int h3 = device.HandleFor(d3);
+
+            bool distinctHandles = h1 != h2 && h2 != h3 && h1 != h3;
+            bool allWritten = device.IsAtLevel(h1, windowsLevel) && device.IsAtLevel(h2, windowsLevel) && device.IsAtLevel(h3, windowsLevel);
+            checklist.Check(distinctHandles && allWritten,
+                "N3: all three distinct displays (two held from the work-list, one the primary) are written to the Windows level in a single restore");
+        }
+
+        // N4 (drain). Mutation this guards: never clear a display from the work-list once it is
+        // restored.
+        private static void CheckNvidiaRestoreDrainsWorkList(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string primary = "\\\\.\\DISPLAY_TESTONLY_N4_PRIMARY";
+            const string worklistDevice = "\\\\.\\DISPLAY_TESTONLY_N4";
+            const int windowsLevel = 12;
+
+            VibranceRestoreHelper.RecordGameLevelApplied(worklistDevice);
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, primary, new List<int>(), windowsLevel, true);
+
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 0,
+                string.Format("N4: HoldingCount is 0 after a fully successful restore, got {0}", VibranceRestoreHelper.HoldingCount));
+
+            device.ResolvedDeviceNames.Clear();
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, primary, new List<int>(), windowsLevel, true);
+
+            checklist.Check(device.ResolvedDeviceNames.Count == 1 && device.ResolvedDeviceNames[0] == primary,
+                string.Format("N4: the second restore's scope is the primary alone - worklistDevice was already drained, got [{0}]",
+                    string.Join(",", device.ResolvedDeviceNames)));
+        }
+
+        // N5 (retry). Mutation this guards: drain a display from the work-list unconditionally,
+        // even when its write failed.
+        private static void CheckNvidiaRestoreRetriesFailedWrite(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string d2 = "\\\\.\\DISPLAY_TESTONLY_N5";
+            const int windowsLevel = 8;
+
+            VibranceRestoreHelper.RecordGameLevelApplied(d2);
+            device.FailNextSetLevel(d2);
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, null, new List<int>(), windowsLevel, true);
+
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 1,
+                string.Format("N5: a display whose write failed is still on the work-list, got HoldingCount={0}", VibranceRestoreHelper.HoldingCount));
+
+            // The underlying failure is gone now (FailNextSetLevel only failed the one call) - the
+            // next restore (as the next foreground event would trigger) must retry and succeed.
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, null, new List<int>(), windowsLevel, true);
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 0,
+                "N5: a later restore, with the underlying failure gone, drains it");
+        }
+
+        // N6 (unresolvable). Mutation this guards: skip the -1/0 guard and pass an unresolved
+        // handle straight to SetLevel.
+        private static void CheckNvidiaRestoreGuardsUnresolvableHandle(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string d2 = "\\\\.\\DISPLAY_TESTONLY_N6";
+            const int windowsLevel = 5;
+
+            VibranceRestoreHelper.RecordGameLevelApplied(d2);
+            device.SetUnresolvable(d2);
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, null, new List<int>(), windowsLevel, true);
+
+            bool neverCalledWithInvalidHandle = !device.SetLevelCalls.Contains(-1) && !device.SetLevelCalls.Contains(0);
+            checklist.Check(neverCalledWithInvalidHandle && device.SetLevelCalls.Count == 0,
+                "N6: SetLevel was never called - not with -1, not with 0 - for a display NvAPI cannot resolve");
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 1, "N6: the unresolvable display stays on the work-list");
+        }
+
+        // N7 (read-back). Mutation this guards: drop the IsAtLevel check and always call SetLevel.
+        private static void CheckNvidiaRestoreSkipsWriteWhenAlreadyAtLevel(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string d2 = "\\\\.\\DISPLAY_TESTONLY_N7";
+            const int windowsLevel = 17;
+
+            VibranceRestoreHelper.RecordGameLevelApplied(d2);
+            device.SeedLevel(d2, windowsLevel);
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, null, new List<int>(), windowsLevel, true);
+
+            checklist.Check(device.SetLevelCalls.Count == 0, "N7: no SetLevel call was made for a display already at the Windows level");
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 0, "N7: it is still drained from the work-list via the read-back alone");
+        }
+
+        // N8 (record only what landed). Drives the REAL, private static OnWinEventHook via
+        // reflection (ResetForTests swaps in the fake device and a matched ApplicationSetting, no
+        // constructor and so no initializeLibrary() involved) rather than re-implementing
+        // OnWinEventHook's own "if (ApplyGameVibranceLevel(...)) RecordGameLevelApplied(...)" gate
+        // inline here - a regression that made that call site record unconditionally would not be
+        // caught by testing ApplyGameVibranceLevel's return value alone. neverChangeResolution is
+        // forced true so this reaches only the vibrance apply branch, not a real resolution change
+        // on the machine running this fixture. Mutation this guards: record a display as owing a
+        // restore before checking ApplyGameVibranceLevel's result (e.g. moving
+        // RecordGameLevelApplied outside the "if").
+        private static void CheckNvidiaApplyOnlyRecordsALandedWrite(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+
+            const int ingameLevel = 60;
+            ApplicationSetting matchingSetting = new ApplicationSetting();
+            matchingSetting.Name = "TestGameN8";
+            matchingSetting.IngameLevel = ingameLevel;
+            List<ApplicationSetting> settings = new List<ApplicationSetting> { matchingSetting };
+
+            VibranceInfo vibranceInfo = new VibranceInfo();
+            vibranceInfo.neverChangeResolution = true;
+            NvidiaDynamicVibranceProxy.ResetForTests(device, vibranceInfo, settings);
+
+            IntPtr desktop = GetDesktopWindow();
+            string gameDeviceName = Screen.FromHandle(desktop).DeviceName;
+            device.FailNextSetLevel(gameDeviceName);
+
+            MethodInfo onWinEventHook = typeof(NvidiaDynamicVibranceProxy).GetMethod(
+                "OnWinEventHook", BindingFlags.NonPublic | BindingFlags.Static);
+            WinEventHookEventArgs args = new WinEventHookEventArgs
+            {
+                Handle = desktop,
+                ProcessName = "TestGameN8"
+            };
+            onWinEventHook.Invoke(null, new object[] { null, args });
+
+            checklist.Check(device.SetLevelCalls.Count == 1,
+                "N8: the apply branch actually attempted the (failing) write");
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 0,
+                string.Format("N8: OnWinEventHook's apply branch never records a display as owing a restore when the write failed, got HoldingCount={0}", VibranceRestoreHelper.HoldingCount));
+        }
+
+        // N9 (flag off unchanged). PIN, not regression evidence for this fix - it passes against a
+        // correct pre-fix implementation too. The affectPrimaryMonitorOnly == false branch was
+        // never gated on focus and is not part of issues #60/#36/#95/#144; this only proves
+        // RestoreWindowsVibranceLevel's refactor left it byte-for-byte equivalent to the pre-fix
+        // "displayHandles.TrueForAll(...)/.ForEach(...)" code.
+        private static void CheckNvidiaRestoreAllDisplaysBranchUnchanged(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string leftoverWorkListDevice = "\\\\.\\DISPLAY_TESTONLY_N9_LEFTOVER";
+            VibranceRestoreHelper.RecordGameLevelApplied(leftoverWorkListDevice);
+
+            List<int> displayHandles = new List<int> { 501, 502, 503 };
+            const int windowsLevel = 33;
+
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, false, null, displayHandles, windowsLevel, true);
+
+            bool allWrittenOnce = device.SetLevelCalls.Count == 3 &&
+                device.SetLevelCalls.Contains(501) && device.SetLevelCalls.Contains(502) && device.SetLevelCalls.Contains(503);
+            checklist.Check(allWrittenOnce, string.Format(
+                "N9 (pin, passes pre-fix too): all three seeded displayHandles entries were written exactly once each, got [{0}]",
+                string.Join(",", device.SetLevelCalls)));
+
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 0,
+                "N9 (pin, passes pre-fix too): the work-list is dropped once the all-displays branch runs, even though nothing on it was individually restored");
+        }
+
+        // N10 (HandleDvcExit). Mutation this guards: write the Windows level unconditionally, as
+        // the pre-fix "setDVCLevel(_vibranceInfo.defaultHandle, ...)" in HandleDvcExit did, instead
+        // of consulting the read-back first.
+        private static void CheckNvidiaHandleDvcExitRestoresPrimaryGuardedByReadBack(Checklist checklist)
+        {
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            NvidiaDynamicVibranceProxy.ResetForTests(device, new VibranceInfo(), new List<ApplicationSetting>());
+
+            const string primary = "\\\\.\\DISPLAY_TESTONLY_N10_PRIMARY";
+            const int windowsLevel = 21;
+
+            // Stands in for HandleDvcExit's own call, with an empty work-list and the flag on.
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, primary, new List<int>(), windowsLevel, true);
+            checklist.Check(device.SetLevelCalls.Count == 1 && device.SetLevelCalls[0] == device.HandleFor(primary),
+                "N10: the first call (empty work-list, flag on) writes the primary exactly once");
+
+            // A later call - as a second HandleDvcExit-shaped restore, or the next foreground event
+            // - with the primary already at the Windows level, must make no SetLevel call at all:
+            // the read-back decides, not an unconditional write.
+            device.SetLevelCalls.Clear();
+            NvidiaDynamicVibranceProxy.RestoreWindowsVibranceLevel(device, true, primary, new List<int>(), windowsLevel, true);
+            checklist.Check(device.SetLevelCalls.Count == 0,
+                "N10: a later call, with the primary already at the Windows level, makes no SetLevel call");
+        }
+
+        // N11 (#95/#144). N2-N10 above all call RestoreWindowsVibranceLevel DIRECTLY - that seam
+        // has no "current screen" parameter at all, so none of them can see a gate wrapped AROUND
+        // the call, which is exactly where the pre-fix
+        // "if (_vibranceInfo.affectPrimaryMonitorOnly && !equalsDVCLevel(defaultHandle,
+        // userVibranceSettingDefault)) { if (_gameScreen == null ||
+        // _gameScreen.DeviceName.Equals(currentScreen.DeviceName)) { ... } else { return; } }"
+        // gate sat, in OnWinEventHook itself (immediately above the call this replaced) - upstream's
+        // actual pre-fix shape inverts that inner condition into "if (_gameScreen != null &&
+        // !_gameScreen.DeviceName.Equals(currentScreen.DeviceName)) { return; }", an early return
+        // out of the whole handler, but the effect on this check is the same: a mismatch between
+        // _gameScreen and the restore event's own screen must not block the write. This is the only
+        // NVIDIA check that reaches the real call site: it reflects into the actual private static
+        // OnWinEventHook (as N8 already does for the apply branch) with _gameScreen forced - via
+        // reflection, Screen has no public constructor - to a real screen DIFFERENT from the one the
+        // restore event itself resolves to, then asserts the write still happens. A version of this
+        // fixture that called RestoreWindowsVibranceLevel directly with a synthetic DeviceName
+        // instead, asserting the same "gets written" outcome, could never have caught a regression
+        // that reinstated the gate around the call site - only reflecting into OnWinEventHook itself
+        // can. Confirmed by mutation: temporarily reinstating upstream's original gate around the
+        // RestoreWindowsVibranceLevel call site turns this specific check red while N2-N10 stay
+        // green.
+        //
+        // Needs two real, distinct monitors to force a mismatch - Skip on a single-monitor machine,
+        // the convention the AMD checks below already use for their own real-focus dependency.
+        private static void CheckNvidiaRestoreReachesRealCallSiteRegardlessOfGameScreen(Checklist checklist)
+        {
+            IntPtr desktop = GetDesktopWindow();
+            Screen currentScreen = Screen.FromHandle(desktop);
+            Screen otherScreen = null;
+            foreach (Screen candidate in Screen.AllScreens)
+            {
+                if (!candidate.DeviceName.Equals(currentScreen.DeviceName))
+                {
+                    otherScreen = candidate;
+                    break;
+                }
+            }
+            if (otherScreen == null)
+            {
+                checklist.Skip("N11: the real OnWinEventHook restore branch reaches RestoreWindowsVibranceLevel regardless of _gameScreen - only one real monitor is attached, cannot force _gameScreen to differ from the current screen");
+                return;
+            }
+
+            FakeNvidiaVibranceDevice device = new FakeNvidiaVibranceDevice();
+            VibranceInfo vibranceInfo = new VibranceInfo();
+            vibranceInfo.affectPrimaryMonitorOnly = true;
+            vibranceInfo.neverChangeResolution = true;
+            // Otherwise RestoreWindowsVibranceLevel's own isWindowsLevelKnown guard (added for NB1)
+            // would make this a no-op regardless of the gate under test.
+            vibranceInfo.isWindowsLevelKnown = true;
+            // See CreateNonMatchingApplicationSetting's comment below (AMD section) - NVIDIA's
+            // OnWinEventHook gates its whole body on "_applicationSettings.Count > 0" the same
+            // way, so an empty list here would never reach the restore branch this check
+            // exercises.
+            List<ApplicationSetting> nonMatchingSettings = new List<ApplicationSetting> { CreateNonMatchingApplicationSetting() };
+            NvidiaDynamicVibranceProxy.ResetForTests(device, vibranceInfo, nonMatchingSettings);
+
+            // _gameScreen has no production setter reachable without a live game event - reflection
+            // is the only way to force it here, same justification as N8 reflecting into
+            // OnWinEventHook itself.
+            FieldInfo gameScreenField = typeof(NvidiaDynamicVibranceProxy).GetField(
+                "_gameScreen", BindingFlags.NonPublic | BindingFlags.Static);
+            gameScreenField.SetValue(null, otherScreen);
+
+            MethodInfo onWinEventHook = typeof(NvidiaDynamicVibranceProxy).GetMethod(
+                "OnWinEventHook", BindingFlags.NonPublic | BindingFlags.Static);
+            // GetDesktopWindow() is a stable handle - unlike AMD's restore branch, NVIDIA's checks
+            // isWindowActive through the fake device (always true here), never the real foreground
+            // window, so there is no focus race to guard against for this one.
+            WinEventHookEventArgs args = new WinEventHookEventArgs
+            {
+                Handle = desktop,
+                ProcessName = "doesnotmatter"
+            };
+            onWinEventHook.Invoke(null, new object[] { null, args });
+
+            checklist.Check(device.SetLevelCalls.Count > 0,
+                "N11: the restore branch's real call site still restores the Windows level when _gameScreen names a different real screen than the current one - 0 SetLevel calls means a focus/current-screen gate has been reinstated around the call");
+        }
+
+        // ------------------------------------------------------------------
+        // AMD - the real OnWinEventHook via reflection, plus a FakeAmdAdapter. These would run
+        // against a build with no VibranceRestoreHelper recording/restore (i.e. this repository
+        // before the fix commit) and FAIL there - see each check's own comment for which ones are
+        // pins instead.
+        // ------------------------------------------------------------------
+
+        private static void RunAmdChecks(Checklist checklist)
+        {
+            checklist.Lines.Add("AMD apply/restore (real OnWinEventHook via reflection + FakeAmdAdapter):");
+
+            CheckAmdRestoreConsultsAffectPrimaryMonitorOnly(checklist);
+            CheckAmdRestoreTargetsGamesScreenAfterApply(checklist);
+            CheckAmdRestoreDrainsWorkList(checklist);
+            CheckAmdRestoreAllDisplaysBranchUnchanged(checklist);
+            CheckAmdRestoreWritesEveryDisplayRecordedByAnAllDisplaysApply(checklist);
+            CheckAmdRestoreReachesRealCallSiteRegardlessOfGameScreen(checklist);
+
+            checklist.Lines.Add(string.Empty);
+        }
+
+        // A1 (#60 on AMD). Mutation this guards: restore back to the unconditional
+        // SetSaturationOnAllDisplays(...) call AmdDynamicVibranceProxy made regardless of
+        // affectPrimaryMonitorOnly.
+        private static void CheckAmdRestoreConsultsAffectPrimaryMonitorOnly(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+
+            FakeAmdAdapter adapter = new FakeAmdAdapter();
+            List<ApplicationSetting> nonMatchingSettings = new List<ApplicationSetting> { CreateNonMatchingApplicationSetting() };
+            Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> windowsResolutionSettings =
+                new Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>();
+
+            AmdDynamicVibranceProxy proxy = new AmdDynamicVibranceProxy(adapter, nonMatchingSettings, windowsResolutionSettings);
+            proxy.SetAffectPrimaryMonitorOnly(true);
+            const int windowsLevel = 44;
+            proxy.SetVibranceWindowsLevel(windowsLevel);
+
+            MethodInfo onWinEventHook = GetOnWinEventHook();
+
+            // This test is dependent on the real foreground window (GetForegroundWindow() is what
+            // AmdDynamicVibranceProxy's own restore branch gates on, not a mockable seam), so its
+            // precondition - the foreground window not changing mid test - is checked before and
+            // after and the check is Skipped, not failed, if it was disturbed by something outside
+            // this fixture's control.
+            IntPtr foregroundBefore = AmdDynamicVibranceProxy.GetForegroundWindow();
+            WinEventHookEventArgs args = new WinEventHookEventArgs
+            {
+                Handle = foregroundBefore,
+                ProcessName = "doesnotmatter"
+            };
+
+            onWinEventHook.Invoke(proxy, new object[] { null, args });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A1: AMD restore honours affectPrimaryMonitorOnly - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            checklist.Check(adapter.SetSaturationOnAllDisplaysCallCount == 0,
+                string.Format("A1: SetSaturationOnAllDisplays was never called with the flag on, got {0} calls", adapter.SetSaturationOnAllDisplaysCallCount));
+
+            string expectedPrimary = VibranceRestoreHelper.GetPrimaryDeviceName();
+            bool wroteThePrimaryOnce = adapter.SetSaturationOnDisplayNames.Count == 1 &&
+                adapter.SetSaturationOnDisplayNames[0] == expectedPrimary &&
+                adapter.SetSaturationOnDisplayLevels[0] == windowsLevel;
+            checklist.Check(wroteThePrimaryOnce, string.Format(
+                "A1: SetSaturationOnDisplay({0}, {1}) ran exactly once, got [{2}]", windowsLevel, expectedPrimary,
+                string.Join(",", adapter.SetSaturationOnDisplayNames)));
+        }
+
+        // A2. Mutation this guards: restore the game's own screen from _gameScreen instead of from
+        // the work-list (would still happen to pass while the work-list and _gameScreen agree, but
+        // is checked here against ComposeRestoreTargets' actual scope, not the field).
+        private static void CheckAmdRestoreTargetsGamesScreenAfterApply(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+
+            const int ingameLevel = 250;
+            const int windowsLevel = 44;
+            ApplicationSetting matchingSetting = new ApplicationSetting();
+            matchingSetting.Name = "TestGameA2";
+            matchingSetting.IngameLevel = ingameLevel;
+
+            List<ApplicationSetting> settings = new List<ApplicationSetting> { matchingSetting };
+            FakeAmdAdapter adapter = new FakeAmdAdapter();
+            Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> windowsResolutionSettings =
+                new Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>();
+
+            AmdDynamicVibranceProxy proxy = new AmdDynamicVibranceProxy(adapter, settings, windowsResolutionSettings);
+            proxy.SetAffectPrimaryMonitorOnly(true);
+            proxy.SetVibranceWindowsLevel(windowsLevel);
+            // Not what this test checks; left on, it could touch this machine's real desktop
+            // resolution, since ApplicationSetting.IsResolutionChangeNeeded defaults to false but
+            // this guards against it regardless.
+            proxy.SetNeverSwitchResolution(true);
+
+            MethodInfo onWinEventHook = GetOnWinEventHook();
+
+            IntPtr desktop = GetDesktopWindow();
+            string gameDeviceName = Screen.FromHandle(desktop).DeviceName;
+
+            WinEventHookEventArgs applyArgs = new WinEventHookEventArgs
+            {
+                Handle = desktop,
+                ProcessName = "TestGameA2"
+            };
+            onWinEventHook.Invoke(proxy, new object[] { null, applyArgs });
+
+            checklist.Check(adapter.SetSaturationOnDisplayNames.Count == 1 &&
+                adapter.SetSaturationOnDisplayNames[0] == gameDeviceName &&
+                adapter.SetSaturationOnDisplayLevels[0] == ingameLevel,
+                "A2: the apply half wrote the ingame level to the game's own screen");
+
+            // Independent of which physical monitor happens to be primary on the machine
+            // running this fixture (the restore assertion below cannot tell "recorded, then
+            // restored" apart from "never recorded, but restored anyway because it coincided
+            // with the primary" when the game's own screen and the primary are the same
+            // display) - this checks the recording mechanism itself, directly.
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 1, string.Format(
+                "A2: exactly the game's own screen is recorded as owing a restore after the apply, got HoldingCount={0}",
+                VibranceRestoreHelper.HoldingCount));
+
+            IntPtr foregroundBefore = AmdDynamicVibranceProxy.GetForegroundWindow();
+            WinEventHookEventArgs restoreArgs = new WinEventHookEventArgs
+            {
+                Handle = foregroundBefore,
+                ProcessName = "doesnotmatter"
+            };
+            onWinEventHook.Invoke(proxy, new object[] { null, restoreArgs });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A2: AMD restore targets the game's screen - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            bool restoredGamesScreen = adapter.SetSaturationOnDisplayNames.Count == 2 &&
+                adapter.SetSaturationOnDisplayNames[1] == gameDeviceName &&
+                adapter.SetSaturationOnDisplayLevels[1] == windowsLevel;
+            checklist.Check(restoredGamesScreen, string.Format(
+                "A2: the restore half wrote the Windows level back to the same screen the game applied to, got [{0}]",
+                string.Join(",", adapter.SetSaturationOnDisplayNames)));
+        }
+
+        // A3 (drain). Mutation this guards: never clear a display from the work-list once it is
+        // restored (AMD's counterpart to N4/N5 - AMD has no read-back to retry against, so only
+        // the drain itself is checked here).
+        private static void CheckAmdRestoreDrainsWorkList(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+
+            FakeAmdAdapter adapter = new FakeAmdAdapter();
+            List<ApplicationSetting> nonMatchingSettings = new List<ApplicationSetting> { CreateNonMatchingApplicationSetting() };
+            Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> windowsResolutionSettings =
+                new Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>();
+
+            AmdDynamicVibranceProxy proxy = new AmdDynamicVibranceProxy(adapter, nonMatchingSettings, windowsResolutionSettings);
+            proxy.SetAffectPrimaryMonitorOnly(true);
+            const int windowsLevel = 60;
+            proxy.SetVibranceWindowsLevel(windowsLevel);
+
+            const string extraDevice = "\\\\.\\DISPLAY_TESTONLY_A3_EXTRA";
+            VibranceRestoreHelper.RecordGameLevelApplied(extraDevice);
+
+            MethodInfo onWinEventHook = GetOnWinEventHook();
+
+            IntPtr foregroundBefore = AmdDynamicVibranceProxy.GetForegroundWindow();
+            WinEventHookEventArgs args = new WinEventHookEventArgs
+            {
+                Handle = foregroundBefore,
+                ProcessName = "doesnotmatter"
+            };
+
+            onWinEventHook.Invoke(proxy, new object[] { null, args });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A3: AMD restore drains the work-list - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            checklist.Check(adapter.SetSaturationOnDisplayNames.Count == 2,
+                string.Format("A3: the first restore wrote both the extra work-list entry and the primary, got {0} calls", adapter.SetSaturationOnDisplayNames.Count));
+            checklist.Check(VibranceRestoreHelper.HoldingCount == 0, "A3: the work-list is empty after the first restore");
+
+            onWinEventHook.Invoke(proxy, new object[] { null, args });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A3: AMD restore drains the work-list (second call) - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            bool secondCallOnlyPrimary = adapter.SetSaturationOnDisplayNames.Count == 3 &&
+                adapter.SetSaturationOnDisplayNames[2] == VibranceRestoreHelper.GetPrimaryDeviceName();
+            checklist.Check(secondCallOnlyPrimary, string.Format(
+                "A3: the second restore only re-touches the primary, not the already-drained extra entry, got [{0}]",
+                string.Join(",", adapter.SetSaturationOnDisplayNames)));
+        }
+
+        // A4 (flag off unchanged). PIN, not regression evidence - see N9's comment for the
+        // convention. The affectPrimaryMonitorOnly == false branch already called
+        // SetSaturationOnAllDisplays unconditionally before this fix too (both in the restore
+        // branch and in HandleDvcExit); this only proves the refactor into
+        // RestoreWindowsVibranceLevel left that branch equivalent.
+        private static void CheckAmdRestoreAllDisplaysBranchUnchanged(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+
+            FakeAmdAdapter adapter = new FakeAmdAdapter();
+            List<ApplicationSetting> nonMatchingSettings = new List<ApplicationSetting> { CreateNonMatchingApplicationSetting() };
+            Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> windowsResolutionSettings =
+                new Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>();
+
+            AmdDynamicVibranceProxy proxy = new AmdDynamicVibranceProxy(adapter, nonMatchingSettings, windowsResolutionSettings);
+            // affectPrimaryMonitorOnly defaults to false - never set, so this exercises that
+            // branch, not a chosen one.
+            const int windowsLevel = 70;
+            proxy.SetVibranceWindowsLevel(windowsLevel);
+
+            MethodInfo onWinEventHook = GetOnWinEventHook();
+
+            IntPtr foregroundBefore = AmdDynamicVibranceProxy.GetForegroundWindow();
+            WinEventHookEventArgs args = new WinEventHookEventArgs
+            {
+                Handle = foregroundBefore,
+                ProcessName = "doesnotmatter"
+            };
+
+            onWinEventHook.Invoke(proxy, new object[] { null, args });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A4: AMD restore with the flag off - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            checklist.Check(adapter.SetSaturationOnAllDisplaysCallCount == 1 && adapter.LastSetSaturationOnAllDisplaysLevel == windowsLevel,
+                string.Format("A4 (pin, passes pre-fix too): SetSaturationOnAllDisplays ran exactly once with the Windows level ({0})", windowsLevel));
+            checklist.Check(adapter.SetSaturationOnDisplayNames.Count == 0,
+                "A4 (pin, passes pre-fix too): SetSaturationOnDisplay was never called with the flag off");
+        }
+
+        // A5 (toggle strand). Guard on the new recording mechanism itself, not regression evidence
+        // for this fix - AMD's all-displays apply branch happens to cover every attached display by
+        // accident even before the fix (it always called SetSaturationOnAllDisplays regardless of
+        // the flag). The real, flag-scoped counterpart to this is N3 on the NVIDIA side. This exists
+        // so a future change to the recording in the unchecked apply branch cannot silently start
+        // recording (and therefore restoring) fewer displays than it actually wrote.
+        private static void CheckAmdRestoreWritesEveryDisplayRecordedByAnAllDisplaysApply(Checklist checklist)
+        {
+            VibranceRestoreHelper.ResetForTests();
+
+            const int ingameLevel = 280;
+            const int windowsLevel = 90;
+            ApplicationSetting matchingSetting = new ApplicationSetting();
+            matchingSetting.Name = "TestGameA5";
+            matchingSetting.IngameLevel = ingameLevel;
+
+            List<ApplicationSetting> settings = new List<ApplicationSetting> { matchingSetting };
+            FakeAmdAdapter adapter = new FakeAmdAdapter();
+            Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> windowsResolutionSettings =
+                new Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>();
+
+            AmdDynamicVibranceProxy proxy = new AmdDynamicVibranceProxy(adapter, settings, windowsResolutionSettings);
+            // Starts off - the all-displays apply branch.
+            proxy.SetVibranceWindowsLevel(windowsLevel);
+            proxy.SetNeverSwitchResolution(true);
+
+            MethodInfo onWinEventHook = GetOnWinEventHook();
+
+            IntPtr desktop = GetDesktopWindow();
+            WinEventHookEventArgs applyArgs = new WinEventHookEventArgs
+            {
+                Handle = desktop,
+                ProcessName = "TestGameA5"
+            };
+            onWinEventHook.Invoke(proxy, new object[] { null, applyArgs });
+
+            checklist.Check(adapter.SetSaturationOnAllDisplaysCallCount == 1,
+                "A5: the flag-off apply wrote every display through SetSaturationOnAllDisplays, not per-display");
+
+            // Ground truth for what the flag-off apply just wrote, taken independently of
+            // VibranceRestoreHelper - not via ComposeRestoreTargets, which is itself downstream of
+            // the very recording this check exists to guard, and so would silently under-report
+            // right alongside an under-recording regression instead of catching it.
+            List<string> expectedTargets = new List<string>();
+            foreach (Screen attachedScreen in Screen.AllScreens)
+            {
+                expectedTargets.Add(attachedScreen.DeviceName);
+            }
+
+            proxy.SetAffectPrimaryMonitorOnly(true);
+
+            IntPtr foregroundBefore = AmdDynamicVibranceProxy.GetForegroundWindow();
+            WinEventHookEventArgs restoreArgs = new WinEventHookEventArgs
+            {
+                Handle = foregroundBefore,
+                ProcessName = "doesnotmatter"
+            };
+            onWinEventHook.Invoke(proxy, new object[] { null, restoreArgs });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A5: AMD restore after a flag toggle - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            bool everyExpectedTargetWritten = true;
+            foreach (string name in expectedTargets)
+            {
+                int index = adapter.SetSaturationOnDisplayNames.IndexOf(name);
+                if (index < 0 || adapter.SetSaturationOnDisplayLevels[index] != windowsLevel)
+                {
+                    everyExpectedTargetWritten = false;
+                    break;
+                }
+            }
+            checklist.Check(everyExpectedTargetWritten && adapter.SetSaturationOnDisplayNames.Count == expectedTargets.Count,
+                string.Format("A5: every display recorded by the flag-off apply ([{0}]) was written the Windows level after the flag flipped on, got [{1}]",
+                    string.Join(",", expectedTargets), string.Join(",", adapter.SetSaturationOnDisplayNames)));
+        }
+
+        // A6, the AMD half of N11. AMD's restore call site never referenced _gameScreen for the
+        // vibrance write in the first place (unlike NVIDIA's pre-fix code) - A1-A5 above already
+        // drive the real call site, a structural advantage NVIDIA's checks lack, but on a machine
+        // where GetDesktopWindow() and GetForegroundWindow() resolve to the same monitor,
+        // _gameScreen and currentScreen coincide by accident and a hypothetical reinstated gate
+        // would never block. This forces _gameScreen (via reflection - AmdDynamicVibranceProxy's
+        // own private static field) to a real screen DIFFERENT from the restore event's actual
+        // current screen, then confirms the write still happens - guarding against that coincidence
+        // quietly hiding a future regression, the AMD counterpart to N11. Needs two real, distinct
+        // monitors - Skip otherwise, and guarded against a real focus change like every other AMD
+        // check above.
+        private static void CheckAmdRestoreReachesRealCallSiteRegardlessOfGameScreen(Checklist checklist)
+        {
+            // Screen.FromHandle(GetForegroundWindow()), not GetDesktopWindow() - the restore
+            // branch resolves its own "screen" from the real foreground window handle (it has no
+            // fake device to substitute a stable one, unlike NVIDIA's N11), so otherScreen must be
+            // guaranteed different from THAT, not from the desktop's screen. The two coincide on
+            // most single-purpose test machines (whatever currently has focus is usually on the
+            // primary monitor, which is also what GetDesktopWindow() resolves to) but not
+            // reliably - using the wrong reference window let this check pass even with a gate
+            // reinstated, whenever the real foreground window happened to already be on the same
+            // monitor picked as "other".
+            Screen currentScreen = Screen.FromHandle(AmdDynamicVibranceProxy.GetForegroundWindow());
+            Screen otherScreen = null;
+            foreach (Screen candidate in Screen.AllScreens)
+            {
+                if (!candidate.DeviceName.Equals(currentScreen.DeviceName))
+                {
+                    otherScreen = candidate;
+                    break;
+                }
+            }
+            if (otherScreen == null)
+            {
+                checklist.Skip("A6: the real OnWinEventHook restore branch reaches RestoreWindowsVibranceLevel regardless of _gameScreen - only one real monitor is attached, cannot force _gameScreen to differ from the current screen");
+                return;
+            }
+
+            VibranceRestoreHelper.ResetForTests();
+
+            FakeAmdAdapter adapter = new FakeAmdAdapter();
+            List<ApplicationSetting> nonMatchingSettings = new List<ApplicationSetting> { CreateNonMatchingApplicationSetting() };
+            Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>> windowsResolutionSettings =
+                new Dictionary<string, Tuple<ResolutionModeWrapper, List<ResolutionModeWrapper>>>();
+
+            AmdDynamicVibranceProxy proxy = new AmdDynamicVibranceProxy(adapter, nonMatchingSettings, windowsResolutionSettings);
+            proxy.SetAffectPrimaryMonitorOnly(true);
+            const int windowsLevel = 55;
+            proxy.SetVibranceWindowsLevel(windowsLevel);
+
+            FieldInfo gameScreenField = typeof(AmdDynamicVibranceProxy).GetField(
+                "_gameScreen", BindingFlags.NonPublic | BindingFlags.Static);
+            gameScreenField.SetValue(null, otherScreen);
+
+            MethodInfo onWinEventHook = GetOnWinEventHook();
+
+            IntPtr foregroundBefore = AmdDynamicVibranceProxy.GetForegroundWindow();
+            WinEventHookEventArgs args = new WinEventHookEventArgs
+            {
+                Handle = foregroundBefore,
+                ProcessName = "doesnotmatter"
+            };
+            onWinEventHook.Invoke(proxy, new object[] { null, args });
+
+            if (AmdDynamicVibranceProxy.GetForegroundWindow() != foregroundBefore)
+            {
+                checklist.Skip("A6: the real OnWinEventHook restore branch reaches RestoreWindowsVibranceLevel regardless of _gameScreen - the foreground window changed mid test, its precondition was destroyed by a real focus change");
+                return;
+            }
+
+            checklist.Check(adapter.SetSaturationOnDisplayNames.Count > 0,
+                "A6: the restore branch's real call site still restores the Windows level when _gameScreen names a different real screen than the current one");
+        }
+
+        private static MethodInfo GetOnWinEventHook()
+        {
+            return typeof(AmdDynamicVibranceProxy).GetMethod(
+                "OnWinEventHook", BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+
+        // Both proxies' OnWinEventHook gate their entire body on
+        // "_applicationSettings.Count > 0" - unlike our own fork's lineage, upstream never
+        // separated that from the per-event match, so an empty settings list here would make
+        // the whole handler, restore branch included, a no-op and never reach the call this
+        // fixture means to exercise. That is itself a latent restore-stranding gap adjacent to
+        // #144/#95 (delete a game's last saved setting while its display still owes a restore
+        // and the next foreground event never drains it either) - out of scope for this fix, not
+        // one of the four confirmed mechanisms, so it is left alone here and worked around
+        // instead: every check below that needs to reach the real restore branch seeds one
+        // decoy ApplicationSetting whose Name can never match a test event's ProcessName, which
+        // keeps Count > 0 without ever taking the apply branch.
+        private static ApplicationSetting CreateNonMatchingApplicationSetting()
+        {
+            ApplicationSetting decoy = new ApplicationSetting();
+            decoy.Name = "NoSuchGame_TESTONLY";
+            return decoy;
+        }
+
+        private static bool SequenceEqual(List<string> actual, List<string> expected)
+        {
+            if (actual.Count != expected.Count)
+                return false;
+            for (int i = 0; i < actual.Count; i++)
+            {
+                if (actual[i] != expected[i])
+                    return false;
+            }
+            return true;
+        }
+
+        // Records every (deviceName -> handle) resolution and every (handle -> level) write this
+        // fake is asked to make - the whole point being that ApplyGameVibranceLevel/
+        // RestoreWindowsVibranceLevel are driven for real against it, not reimplemented here.
+        // Assigns a fresh handle the first time a given deviceName is resolved and reuses it
+        // afterward, exactly like a real display's handle staying stable for the process lifetime.
+        private class FakeNvidiaVibranceDevice : INvidiaVibranceDevice
+        {
+            private readonly Dictionary<string, int> _handlesByDeviceName = new Dictionary<string, int>();
+            private readonly Dictionary<int, int> _levelsByHandle = new Dictionary<int, int>();
+            private readonly HashSet<string> _unresolvable = new HashSet<string>();
+            private readonly HashSet<int> _failNextSetLevel = new HashSet<int>();
+            private int _nextHandle = 1;
+
+            public readonly List<int> SetLevelCalls = new List<int>();
+            public readonly List<string> ResolvedDeviceNames = new List<string>();
+
+            public void SetUnresolvable(string deviceName)
+            {
+                _unresolvable.Add(deviceName);
+            }
+
+            public void SeedLevel(string deviceName, int level)
+            {
+                _levelsByHandle[ResolveOrAssign(deviceName)] = level;
+            }
+
+            public void FailNextSetLevel(string deviceName)
+            {
+                _failNextSetLevel.Add(ResolveOrAssign(deviceName));
+            }
+
+            public int HandleFor(string deviceName)
+            {
+                return ResolveOrAssign(deviceName);
+            }
+
+            private int ResolveOrAssign(string deviceName)
+            {
+                int handle;
+                if (!_handlesByDeviceName.TryGetValue(deviceName, out handle))
+                {
+                    handle = _nextHandle++;
+                    _handlesByDeviceName[deviceName] = handle;
+                }
+                return handle;
+            }
+
+            public bool IsWindowActive(ref IntPtr hWnd)
+            {
+                return true;
+            }
+
+            public int TryResolveDisplayHandle(string deviceName)
+            {
+                ResolvedDeviceNames.Add(deviceName);
+                if (string.IsNullOrEmpty(deviceName) || _unresolvable.Contains(deviceName))
+                {
+                    return -1;
+                }
+                return ResolveOrAssign(deviceName);
+            }
+
+            public bool IsAtLevel(int displayHandle, int level)
+            {
+                int current;
+                return _levelsByHandle.TryGetValue(displayHandle, out current) && current == level;
+            }
+
+            public bool SetLevel(int displayHandle, int level)
+            {
+                SetLevelCalls.Add(displayHandle);
+                if (_failNextSetLevel.Remove(displayHandle))
+                {
+                    return false;
+                }
+                _levelsByHandle[displayHandle] = level;
+                return true;
+            }
+        }
+
+        // Everything IAmdAdapter exposes, none of it touching real hardware, plus the per-display
+        // call log the AMD checks above need.
+        private class FakeAmdAdapter : IAmdAdapter
+        {
+            public int SetSaturationOnAllDisplaysCallCount;
+            public int LastSetSaturationOnAllDisplaysLevel = int.MinValue;
+
+            public readonly List<int> SetSaturationOnDisplayLevels = new List<int>();
+            public readonly List<string> SetSaturationOnDisplayNames = new List<string>();
+
+            public void SetSaturationOnAllDisplays(int vibranceLevel)
+            {
+                SetSaturationOnAllDisplaysCallCount++;
+                LastSetSaturationOnAllDisplaysLevel = vibranceLevel;
+            }
+
+            public void SetSaturationOnDisplay(int vibranceLevel, string displayName)
+            {
+                SetSaturationOnDisplayLevels.Add(vibranceLevel);
+                SetSaturationOnDisplayNames.Add(displayName);
+            }
+
+            public bool IsAvailable()
+            {
+                return false;
+            }
+
+            public void Init()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private class Checklist
+        {
+            public readonly List<string> Lines = new List<string>();
+            public int Passed;
+            public int Total;
+
+            public void Check(bool condition, string description)
+            {
+                Total++;
+                if (condition)
+                    Passed++;
+                Lines.Add(string.Format("[{0}] {1}", condition ? "PASS" : "FAIL", description));
+            }
+
+            // Deliberately not counted in Total/Passed - a Skip means the check's precondition
+            // (usually a second real, distinct monitor, or the real foreground window staying put
+            // for the duration of one reflection call) could not be established on this machine,
+            // not that the code under test failed.
+            public void Skip(string description)
+            {
+                Lines.Add(string.Format("[SKIP] {0}", description));
+            }
+        }
+    }
+}

--- a/vibrance.GUI/common/VibranceRestoreHelper.cs
+++ b/vibrance.GUI/common/VibranceRestoreHelper.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace vibrance.GUI.common
+{
+    /// <summary>
+    /// The vibrance path's counterpart to DeviceGammaRampHelper's restore work-list
+    /// (_devicesHoldingGameRamp). Neither vendor proxy previously kept any record of which
+    /// display(s) it had actually written a GAME vibrance level to - NVIDIA hijacked a single
+    /// "defaultHandle" field that a later game overwrote and a resolution-scoped restore never
+    /// touched (issue #144), and the restore itself was gated on "is the currently focused screen
+    /// the one the game used" instead of "which screen(s) actually need restoring" (issue #95).
+    /// Both proxies share this one work-list because exactly one vendor proxy is ever constructed
+    /// per process (see Program.cs's vendor selection) - there is never a question of which
+    /// proxy's records these are.
+    /// </summary>
+    internal static class VibranceRestoreHelper
+    {
+        // Screen.DeviceName of every display this application has written a GAME vibrance level to
+        // and has not yet written the Windows level back to. Same role and rule as
+        // DeviceGammaRampHelper._devicesHoldingGameRamp: added only when a write actually landed,
+        // drained by restore. Static and shared by whichever vendor proxy this process constructed -
+        // exactly one is ever built. Everything runs on the UI thread (proxy construction,
+        // WINEVENT_OUTOFCONTEXT callbacks, Form1_FormClosing), so deliberately unsynchronised, like
+        // the _gameScreen/_vibranceInfo statics beside it. Keys are \\.\DISPLAYn, a namespace the OS
+        // bounds.
+        private static readonly HashSet<string> _displaysHoldingGameLevel = new HashSet<string>();
+
+        /// <summary>
+        /// Marks deviceName as owing a restore to the Windows vibrance level. A no-op for null or
+        /// empty - never adds a key that ComposeRestoreTargets or a foreach over the set could not
+        /// meaningfully act on.
+        /// </summary>
+        internal static void RecordGameLevelApplied(string deviceName)
+        {
+            if (string.IsNullOrEmpty(deviceName))
+            {
+                return;
+            }
+            _displaysHoldingGameLevel.Add(deviceName);
+        }
+
+        /// <summary>
+        /// Drops deviceName from the work-list, normally once its restore has actually landed (or
+        /// is confirmed unnecessary via a read-back). A no-op for null, empty, or a name not
+        /// currently held.
+        /// </summary>
+        internal static void ClearGameLevelRecord(string deviceName)
+        {
+            if (string.IsNullOrEmpty(deviceName))
+            {
+                return;
+            }
+            _displaysHoldingGameLevel.Remove(deviceName);
+        }
+
+        /// <summary>
+        /// The "affectPrimaryMonitorOnly == false" exit: that path restores every display through
+        /// its own all-displays call, not one at a time through ComposeRestoreTargets, so the
+        /// work-list is cleared in one step by whoever just did that restore.
+        /// </summary>
+        internal static void ClearAllGameLevelRecords()
+        {
+            _displaysHoldingGameLevel.Clear();
+        }
+
+        internal static int HoldingCount
+        {
+            get { return _displaysHoldingGameLevel.Count; }
+        }
+
+        /// <summary>
+        /// The set of displays a restore must visit: every display currently on the work-list,
+        /// plus - only when affectPrimaryMonitorOnly is true - the primary display, appended once,
+        /// even if it is not itself on the work-list (the Windows Vibrance Level always owns the
+        /// primary; it does not need to have been "applied to" first to be due a restore). Never
+        /// null, never contains a null or empty entry, never contains a duplicate.
+        ///
+        /// When affectPrimaryMonitorOnly is false the primary is deliberately NOT appended - that
+        /// scope is the pre-existing "every enumerated display handle" restore, which the caller
+        /// drives through its own list, not through this one. The caller must call
+        /// ClearAllGameLevelRecords() itself after that restore; this method does not mutate
+        /// anything, so it does not do that on the caller's behalf when the flag is false.
+        /// </summary>
+        internal static List<string> ComposeRestoreTargets(bool affectPrimaryMonitorOnly, string primaryDeviceName)
+        {
+            List<string> targets = new List<string>(_displaysHoldingGameLevel);
+            if (affectPrimaryMonitorOnly && !string.IsNullOrEmpty(primaryDeviceName) && !targets.Contains(primaryDeviceName))
+            {
+                targets.Add(primaryDeviceName);
+            }
+            return targets;
+        }
+
+        /// <summary>
+        /// Screen.PrimaryScreen.DeviceName, or null when there is no primary screen (not reachable
+        /// on a real machine, but Screen.PrimaryScreen is itself documented as nullable).
+        /// </summary>
+        internal static string GetPrimaryDeviceName()
+        {
+            Screen primary = Screen.PrimaryScreen;
+            return primary == null ? null : primary.DeviceName;
+        }
+
+        // Exists for VibranceRestoreFixture only - production code never needs to blank this
+        // out mid-run. Mirrors DeviceGammaRampHelper.ResetForTests, which exists for the same
+        // reason.
+        internal static void ResetForTests()
+        {
+            _displaysHoldingGameLevel.Clear();
+        }
+    }
+}

--- a/vibrance.GUI/vibrance.GUI.csproj
+++ b/vibrance.GUI/vibrance.GUI.csproj
@@ -125,6 +125,7 @@
     <Compile Include="common\ResolutionModeWrapper.cs" />
     <Compile Include="common\WinEventHook.cs" />
     <Compile Include="common\WinEventHookEventArgs.cs" />
+    <Compile Include="common\VibranceRestoreHelper.cs" />
     <Compile Include="common\Definitions.cs" />
     <Compile Include="common\GraphicsAdapter.cs" />
     <Compile Include="common\IRegistryController.cs" />

--- a/vibrance.GUI/vibrance.GUI.csproj
+++ b/vibrance.GUI/vibrance.GUI.csproj
@@ -126,6 +126,7 @@
     <Compile Include="common\WinEventHook.cs" />
     <Compile Include="common\WinEventHookEventArgs.cs" />
     <Compile Include="common\VibranceRestoreHelper.cs" />
+    <Compile Include="common\VibranceRestoreFixture.cs" />
     <Compile Include="common\Definitions.cs" />
     <Compile Include="common\GraphicsAdapter.cs" />
     <Compile Include="common\IRegistryController.cs" />


### PR DESCRIPTION
Four issues — #60, #36, #144, #95 — two reporters each, spanning 2021 to 2026. Three mechanisms, all reachable in the **default configuration**: `affectPrimaryMonitorOnly` defaults to `true`.

Split into two commits so the fixes can be taken without the testing convention — see "About the second commit".

## 1. Every launch writes vibrance level 0 to an arbitrary display

This isn't described as a mechanism in any of the reports, and I think it's the literal cause of #60.

`InitializeProxy` (`NvidiaDynamicVibranceProxy.cs:195-203`) sets `defaultHandle = enumerateNvidiaDisplayHandle(0)` and then writes `_vibranceInfo.userVibranceSettingDefault` to it. But `_vibranceInfo = new VibranceInfo()` is constructed a couple of lines earlier, and `SetVibranceWindowsLevel` isn't reached until the background worker runs — **after the constructor returns**. So the value written is the struct default, **0**.

The target, `enumerateNvidiaDisplayHandle(0)`, is the *first enumerated* handle. It has no defined relationship to the primary display. And the write ignores `affectPrimaryMonitorOnly` entirely.

So a second monitor whose vibrance the user deliberately set in the NVIDIA control panel is reset to neutral **at every startup**. #60 reads: *"Affect Primary Monitor only: On. Affects second screen when changing to the Windows Vibrance Level."*

The write is gone. Restore is now a no-op until the real level is known (`isWindowsLevelKnown`).

## 2. The handle it writes through is hijacked and never restored

Applying a game's level overwrites `defaultHandle` at `:231` with that game's display, and never puts it back. Both the restore branch and `HandleDvcExit` write through it — so after the first game on a second monitor, **every** later write of the Windows level lands there, including on exit.

"Affect Primary Monitor only" actually delivers *"only one monitor, whichever the game was last on."*

There's a subtlety that makes #144 worse: the hijack sits behind `if (displayHandle != -1 && !equalsDVCLevel(displayHandle, ingameLevel))`. If the game's display is *already* at its ingame level — restart vibranceGUI while the game runs, or add the game mid-session — the apply is skipped, the handle stays pointing somewhere arbitrary, and the restore writes the Windows level to a display that was never touched while the game's own display is never restored at all.

`defaultHandle` is removed from `VibranceInfo` entirely.

## 3. Restore is scoped to where focus landed, not to what was changed

`:253-262`:

```csharp
if (_vibranceInfo.affectPrimaryMonitorOnly && !equalsDVCLevel(_vibranceInfo.defaultHandle, ...))
{
    if(_gameScreen != null && !_gameScreen.DeviceName.Equals(currentScreen.DeviceName))
    {
        return;
    }
    setDVCLevel(_vibranceInfo.defaultHandle, _vibranceInfo.userVibranceSettingDefault);
}
```

Alt-tab to a window on a different monitor and restore never runs. #95, word for word: *"I shift-tab and press my second monitor to go to my desktop, where the vibrance is not removed and persists."*

**This gate was deliberate** — `9168349`, *"Refactored detection of process switch"* — and its intent is legible: don't kill a game's vibrance when the user clicks something on the other monitor while the game is still visible.

It is removed here on #95's explicit request. The reason it can't stay is that it can only express *"the mouse is elsewhere"*, never *"the game is still running"* — and #144 is what that conflation costs. **Someone who liked the old behaviour will notice.** That's a real trade, not a free fix, and I'd rather say so than bury it.

Considered and rejected: keep the gate but exempt the case where the game process has exited (`OpenProcess`/`GetExitCodeProcess` on a PID already in hand). It would restore the 2017 behaviour's actual defect — alt-tab to monitor 2 with the game still running leaves monitor 1 saturated, which *is* #95 — while adding PID-reuse and handle-lifetime surface to the UI thread inside a WinEvent callback. If "keep game vibrance while the game is visible" is wanted later, the honest mechanism is per-display "is a matched game still on this display", and that's a feature.

## The fix

Vibrance now works from a **record of the displays actually written to**, keyed by `Screen.DeviceName`, unioned with the primary that the Windows Vibrance Level slider owns — and nothing else.

The union matters independently of the four issues: with the setting **off** a game applies to every display, and turning it **on** mid-game previously restored one handle and stranded the rest **permanently**. Since #60 and #36 are both *"I checked this box and my second screen is wrong"*, a user toggling it mid-session is a plausible route into either report.

The enabler already existed: `getAssociatedNvidiaDisplayHandle` (`:93-98`) maps a `DeviceName` to a display handle, and the apply path already depends on it working. So this adds no new dependency on `vibranceDLL.dll` — it just uses the mapping the code already trusts.

**AMD was wrong differently**, in three places. `HandleDvcExit` (`:90`) and the restore branch (`:153`) both called `SetSaturationOnAllDisplays` unconditionally, ignoring the setting the apply path honours. Both now use the same record.

The third, at `:127`, was in the **apply** branch: it wrote the Windows level to every display immediately before applying the game's level — a needless write to displays it has no business touching, on every foreground event. **Removed.** With the flag on it is overwritten for the game's screen and only stomps unrelated displays; with the flag off the following `SetSaturationOnAllDisplays(ingameLevel)` overwrites it everywhere. No display's end state changes in either branch.

## Testing

New `INvidiaVibranceDevice` seam over the four `vibranceDLL.dll` calls the handler makes. Without it none of this is reachable from a test — **which is why three of these four issues shipped.**

New `--selftest-vibrance`: **23 checks, 39 assertions**, driven entirely by fakes. No GPU, no display, no driver.

**Every check was proven to fail** against a targeted mutation, then restored byte-identically and hash-verified.

The one that matters most: `CheckNvidiaRestoreReachesRealCallSiteRegardlessOfGameScreen` reflects into the **real** private static `OnWinEventHook` restore branch with `_gameScreen` forced to a display other than the event's. Reinstating this repo's exact gate — the `return` above — turns it red, and **it is the only one of 39 assertions that moves.**

That check exists because an earlier version of it *couldn't* fail: it called the restore method directly and argued the method takes no "current screen" parameter, which is true but irrelevant — the gate sits one line *above* the call. Two reviewers found that independently by putting the bug back and watching a fully green suite. Worth mentioning because the same trap is easy to fall into when reviewing this.

Two more checks needed real fixes during verification rather than re-runs, both environment-masked:
- One stayed green with the recording deleted, because on the test machine the game's screen and the primary coincide, so restore reached the display via the primary-fallback instead. Replaced with a direct assertion on the record itself.
- Another compared against `GetDesktopWindow()` where the restore branch resolves from `GetForegroundWindow()` — handles that usually coincide but needn't.

## About the second commit

The repo has no test project, so commit 2 adds the fixture and the flag. **It is a separate commit specifically so you can drop it and take only the fixes.**

`--selftest-vibrance` is placed early in `Main`, before adapter detection, so it needs neither vendor's driver.

## Verification and its limits — please read this part

**Warnings unchanged.** `master` builds with 2 (`CS0659` `ResolutionModeWrapper.cs:8`, `CS0168` `WinEventHook.cs:202`); this branch builds with the same 2, both configurations. Neither file is touched here.

**Fody/Costura weaving was never exercised, so the packaged single-file executable was not produced or tested.** Fody 1.26.4 fails on VS2022's MSBuild with a Remoting/AppDomain assembly-resolution error — reproducible on a clean `master` checkout, entirely unrelated to this change. Compilation was verified by skipping the weave step, which runs strictly after the compiler has emitted everything, so the warning comparison above is unaffected. **That skip was achieved by a local modification to a gitignored package cache, not a supported option** — it will not reproduce on your machine, and I mention it so the "clean build" claim above is read as covering compilation and the fixture only.

**The .NET 4.0 constraint is verified by inspection and API scan, not by compilation** — this machine has no v4.0 reference assemblies, so builds use `-p:TargetFrameworkVersion=v4.8`. The csproj still declares `v4.0` and was not edited.

**None of the four issues has been confirmed resolved on a reporter's hardware.** The mechanisms are proven from source and the behaviour from fixtures; the end-to-end fix is not.

## Found but not fixed

**Both proxies gate the entire `OnWinEventHook` body on `_applicationSettings.Count > 0`.** Delete your last saved game while a display still owes a restore, and the next foreground event no-ops instead of draining it. That's a restore-stranding gap adjacent to #144 and #95, but it isn't one of the four mechanisms above and fixing it would widen this change. The fixture works around it with a deliberately non-matching `ApplicationSetting` wherever a check needs to reach the real restore branch.

## Notes for review

- **`LogSafely`** is added to `Program.cs` (upstream's `VibranceGUI.Log` calls `File.AppendText` unguarded, which can throw across a native callback frame). My PR #159 adds an identical one — if both land it's a same-signature, same-body conflict, trivially resolved by keeping either.
- **The NVIDIA apply-branch nesting is preserved exactly.** This repo nests the resolution change and `_gameScreen = screen` inside the "vibrance differs" gate. I kept that rather than widening when those fire, since it's out of scope here — at the cost of one duplicated resolve plus read-back, at foreground-event rate.
- **NVIDIA's apply still ignores `affectPrimaryMonitorOnly`** — it writes only the game's display in both modes. Deliberately unchanged: fixing it would start putting game vibrance on *every* monitor for users with the box unchecked, which no issue asks for.
- `AmdDynamicVibranceProxy.cs` gained a trailing newline it didn't have (whole-file rewrite). No semantic effect, flagged so it isn't a surprise in the diff.
- The checkbox tooltip now reads "your primary monitor and the monitor the game is running on — no others". The checkbox text itself is unchanged.

Happy to drop the fixture commit, split this up, or adjust anything else you'd prefer.
